### PR TITLE
Modified lib folder to macro %{_lib}

### DIFF
--- a/package/rpm/pfring.spec.in
+++ b/package/rpm/pfring.spec.in
@@ -25,7 +25,7 @@ fi
 mkdir -p $RPM_BUILD_ROOT/usr/local/pfring
 mkdir -p $RPM_BUILD_ROOT/usr/local/pfring/kernel
 mkdir -p $RPM_BUILD_ROOT/usr/local/include/linux
-mkdir -p $RPM_BUILD_ROOT/usr/local/lib
+mkdir -p $RPM_BUILD_ROOT/usr/local/%{_lib}
 mkdir -p $RPM_BUILD_ROOT/usr/local/bin
 mkdir -p $RPM_BUILD_ROOT/etc/init.d
 mkdir -p $RPM_BUILD_ROOT/etc/ld.so.conf.d
@@ -36,11 +36,11 @@ cp $HOME/PF_RING/kernel/linux/pf_ring.h $RPM_BUILD_ROOT/usr/local/include/linux/
 # Userland
 cp $HOME/PF_RING/README.FIRST                  $RPM_BUILD_ROOT/usr/local/pfring/
 cp $HOME/PF_RING/userland/snort/pfring-daq-module/README.1st $RPM_BUILD_ROOT/usr/local/pfring/README-DAQ.1st
-cp $HOME/PF_RING/userland/lib/libpfring.a      $RPM_BUILD_ROOT/usr/local/lib
-cp $HOME/PF_RING/userland/lib/libpfring.so     $RPM_BUILD_ROOT/usr/local/lib
+cp $HOME/PF_RING/userland/lib/libpfring.a      $RPM_BUILD_ROOT/usr/local/%{_lib}
+cp $HOME/PF_RING/userland/lib/libpfring.so     $RPM_BUILD_ROOT/usr/local/%{_lib}
 cp $HOME/PF_RING/userland/lib/pfring.h         $RPM_BUILD_ROOT/usr/local/include
 cp $HOME/PF_RING/userland/lib/pfring_zc.h      $RPM_BUILD_ROOT/usr/local/include
-cp $HOME/PF_RING/userland/libpcap/libpcap.a    $RPM_BUILD_ROOT/usr/local/lib
+cp $HOME/PF_RING/userland/libpcap/libpcap.a    $RPM_BUILD_ROOT/usr/local/%{_lib}
 cp $HOME/PF_RING/userland/examples/pfcount     $RPM_BUILD_ROOT/usr/local/bin
 cp $HOME/PF_RING/userland/examples/pfsend      $RPM_BUILD_ROOT/usr/local/bin
 cp $HOME/PF_RING/package/etc/init.d/pf_ring    $RPM_BUILD_ROOT/etc/init.d
@@ -48,11 +48,10 @@ cp $HOME/PF_RING/package/etc/init.d/cluster    $RPM_BUILD_ROOT/etc/init.d
 cp $HOME/PF_RING/package/etc/init/pf_ring.conf $RPM_BUILD_ROOT/etc/init
 cp $HOME/PF_RING/package/etc/ld.so.conf.d/pf_ring.conf $RPM_BUILD_ROOT/etc/ld.so.conf.d/
 # DNA
-mkdir -p $RPM_BUILD_ROOT/usr/local/lib/daq
+mkdir -p $RPM_BUILD_ROOT/usr/local/%{_lib}/daq
 #cp $HOME/PF_RING/userland/snort/pfring-daq-module/.libs/daq_pfring.la $RPM_BUILD_ROOT/usr/local/lib/daq
-cp $HOME/PF_RING/userland/snort/pfring-daq-module/.libs/daq_pfring.so $RPM_BUILD_ROOT/usr/local/lib/daq
-cp $HOME/PF_RING/userland/snort/pfring-daq-module/.libs/daq_pfring.so $RPM_BUILD_ROOT/usr/local/lib/daq
-cp -a $HOME/daq-2.0.0/sfbpf/.libs/libsfbpf.so.0 $HOME/daq-2.0.0/sfbpf/.libs/libsfbpf.so.0.0.1 $RPM_BUILD_ROOT/usr/local/lib
+cp $HOME/PF_RING/userland/snort/pfring-daq-module/.libs/daq_pfring.so $RPM_BUILD_ROOT/usr/local/%{_lib}/daq
+cp -a $HOME/daq-2.0.0/sfbpf/.libs/libsfbpf.so.0 $HOME/daq-2.0.0/sfbpf/.libs/libsfbpf.so.0.0.1 $RPM_BUILD_ROOT/usr/local/%{_lib}
 %if %nodna == 0
 cp $HOME/PF_RING/userland/examples_libzero/pfdnabounce $RPM_BUILD_ROOT/usr/local/bin
 cp $HOME/PF_RING/userland/examples_libzero/pfdnacluster_master $RPM_BUILD_ROOT/usr/local/bin
@@ -69,15 +68,15 @@ rm -fr $RPM_BUILD_ROOT
 
 %files
 /usr/local/include/linux/pf_ring.h
-/usr/local/lib/libpfring.a
-/usr/local/lib/libpfring.so
-/usr/local/lib/libpcap.a
+/usr/local/%{_lib}/libpfring.a
+/usr/local/%{_lib}/libpfring.so
+/usr/local/%{_lib}/libpcap.a
 /usr/local/include/pfring.h
 /usr/local/include/pfring_zc.h
 #/usr/local/lib/daq/daq_pfring.la
-/usr/local/lib/daq/daq_pfring.so
-/usr/local/lib/libsfbpf.so.0
-/usr/local/lib/libsfbpf.so.0.0.1
+/usr/local/%{_lib}/daq/daq_pfring.so
+/usr/local/%{_lib}/libsfbpf.so.0
+/usr/local/%{_lib}/libsfbpf.so.0.0.1
 %if %nodna == 0
 /usr/local/bin/pfdnabounce
 /usr/local/bin/pfdnacluster_master


### PR DESCRIPTION
Hello, this changes are needed by SLES11 SP3 for installing files on the right "lib" folder. I'm supposing this is the same on other distros, so please give it a try before merge.

Regards.
