### PR TITLE
Fix compilation error in Debian 8.1

### DIFF
--- a/drivers/ZC/intel/e1000e/e1000e-3.0.4.1-zc/src/Makefile
+++ b/drivers/ZC/intel/e1000e/e1000e-3.0.4.1-zc/src/Makefile
@@ -88,8 +88,8 @@ VSP :=  $(KOBJ)/include/generated/utsrelease.h \
         /boot/vmlinuz.version.h
 
 # Config file Search Path
-CSP :=  $(KSRC)/include/generated/autoconf.h \
-        $(KSRC)/include/linux/autoconf.h \
+CSP :=  $(KOBJ)/include/generated/autoconf.h \
+        $(KOBJ)/include/linux/autoconf.h \
         /boot/vmlinuz.autoconf.h
 
 # prune the lists down to only files that exist

--- a/drivers/ZC/intel/igb/igb-5.2.5-zc/src/Makefile
+++ b/drivers/ZC/intel/igb/igb-5.2.5-zc/src/Makefile
@@ -97,8 +97,8 @@ VSP :=  $(KOBJ)/include/generated/utsrelease.h \
         /boot/vmlinuz.version.h
 
 # Config file Search Path
-CSP :=  $(KSRC)/include/generated/autoconf.h \
-        $(KSRC)/include/linux/autoconf.h \
+CSP :=  $(KOBJ)/include/generated/autoconf.h \
+        $(KOBJ)/include/linux/autoconf.h \
         /boot/vmlinuz.autoconf.h
 
 # prune the lists down to only files that exist


### PR DESCRIPTION
Fix error "Linux kernel source not configured - missing autoconf.h." when compiling e1000e or igb driver in debian 8.1
