### PR TITLE
Remove the requirement of the network service for starting PF_RING, b…

### DIFF
--- a/package/etc/init.d/pf_ring
+++ b/package/etc/init.d/pf_ring
@@ -8,7 +8,7 @@
 #
 ### BEGIN INIT INFO
 # Provides:          pf_ring
-# Required-Start:    $local_fs $remote_fs $network $syslog
+# Required-Start:    $local_fs $remote_fs $syslog
 # Required-Stop:     $n2disk $nprobe
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6


### PR DESCRIPTION
…ecause after the network service has started it is too late to load the ZC drivers since the vanilla drivers will already have loaded.

This is required when the system only has a single NIC.  For example, an Intel X520 dual-port card where one of the ports is capture, and the other is backplane/management.  The only way to properly load the ZC ixgbe driver is during bootup, and it must be before the network service has started (i.e. before the vanilla drivers have loaded)