### PR TITLE
Revert "Remove the requirement of the network service for starting PF…

### DIFF
--- a/package/etc/init.d/pf_ring
+++ b/package/etc/init.d/pf_ring
@@ -8,7 +8,7 @@
 #
 ### BEGIN INIT INFO
 # Provides:          pf_ring
-# Required-Start:    $local_fs $remote_fs $syslog
+# Required-Start:    $local_fs $remote_fs $network $syslog
 # Required-Stop:     $n2disk $nprobe
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6


### PR DESCRIPTION
…_RING, because after the network service has started it is too late to load the ZC drivers since the vanilla drivers will already have loaded."

This reverts commit 42d36d54805b010115be20410172688834ed4cc6.

Doing a "FORCESTART" (either via the environment variable or the /etc/pf_ring/forcestart file) will actually get around the issue of loading the driver at boot.  So this is not necessary it turns out.