### PR TITLE
Update daq_pfring.c

### DIFF
--- a/userland/snort/pfring-daq-module/daq_pfring.c
+++ b/userland/snort/pfring-daq-module/daq_pfring.c
@@ -856,9 +856,9 @@ static int pfring_daq_inject(void *handle, const DAQ_PktHdr_t *hdr,
   }
 
   char tmp_packet[2000];
-  memcpy(tmp_packet, context->pkt_buffer, 14);//Mahdi: copy Header layer2 packet to tmp_packet
-  memcpy(&tmp_packet[14], packet_data, len); //Mahdi: copy data packet to tmp_packet
-  len += 14;  //Mahdi: Update packet len
+  memcpy(tmp_packet, context->pkt_buffer, 14);//copy Header layer2 packet to tmp_packet
+  memcpy(&tmp_packet[14], packet_data, len); //copy data packet to tmp_packet
+  len += 14;  //Update packet len
 
   if(pfring_send(context->ring_handles[tx_ring_idx],
 		 (char *) tmp_packet, len, 1 /* flush packet */) < 0) {

--- a/userland/snort/pfring-daq-module/daq_pfring.c
+++ b/userland/snort/pfring-daq-module/daq_pfring.c
@@ -847,13 +847,21 @@ static int pfring_daq_inject(void *handle, const DAQ_PktHdr_t *hdr,
 #else
       if (context->ifindexes[i] == hdr->device_index) {
 #endif
-        tx_ring_idx = i ^ 0x1;
+        if(reverse == 1)
+                tx_ring_idx = i;
+        else
+                tx_ring_idx = i ^ 0x1;
         break;
       }
   }
 
+  char tmp_packet[2000];
+  memcpy(tmp_packet, context->pkt_buffer, 14);//Mahdi: copy Header layer2 packet to tmp_packet
+  memcpy(&tmp_packet[14], packet_data, len); //Mahdi: copy data packet to tmp_packet
+  len += 14;  //Mahdi: Update packet len
+
   if(pfring_send(context->ring_handles[tx_ring_idx],
-		 (char *) packet_data, len, 1 /* flush packet */) < 0) {
+		 (char *) tmp_packet, len, 1 /* flush packet */) < 0) {
     DPE(context->errbuf, "%s", "pfring_send() error");
     return DAQ_ERROR;
   }


### PR DESCRIPTION
Bug: In the snort inject packet After attack detector. for example if was blocked syn with rule in snort, and snort receive syn packet, it's block. Then snort send RST packet to client and server. Snort call  pfring_daq_inject for send RST packet.
In this daq_pfring module   after call  pfring_daq_inject sent packet without header level2 . client and server don't receive RST packet.

Solution: In pfring_daq_inject function add header level 2 to packet.
14 byte from source packet copy to tmp_packet, and concat packet_data (for last example "RST packet") to end of tmp_packet and sent it.
Both of client and server receive RST packet from pfring device.
