### PR TITLE
Installation: Fix kernel module installation for custom DESTDIR

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -61,10 +61,18 @@ clean:
 install:
 	mkdir -p $(INSTDIR)
 	cp *.ko $(INSTDIR)
+	mkdir -p $(DESTDIR)/usr/include/linux
 	cp linux/pf_ring.h $(DESTDIR)/usr/include/linux
 	@if test -d ${TARGETDIR}; then \
 		cp linux/pf_ring.h ${TARGETDIR}; \
 	fi
 ifeq (,$(DESTDIR))
 	/sbin/depmod $(BUILD_KERNEL)
+else
+	@echo "*****NOTE:";
+	@echo "pf_ring,ko kernel module installed in ${DESTDIR}";
+	@echo "/sbin/depmod not run.  modprobe pf_ring won't work " ;
+	@echo "You can load the kernel module directly using" ;
+	@echo "insmod <path>/pf_ring.ko" ;
+	@echo "*****";
 endif


### PR DESCRIPTION
Issue:
When the user provides a custom path for the Makefile in $ROOT/kernel
directory, using the command "make install DESTDIR=<path>", it fails at
the stage when it is trying to copy the pf_ring.h header file over to
"<path>/usr/include/linux", if the afore-mentioned path doesn't exist.
The issue doesn't exist when it tries to copy the kernel module
pf_ring.ko over, since it has a "mkdir -p " for that, but the same
doesn't exist for copying the header file.

Solution:
Added a mkdir -p for the above "<path>/usr/include/linux.  There are no
errors if the path already exists.  If it doesn't exist, the path is
created.

Testing:
Verified on a local setup, including building, installing and using the kernel modules and userspace libraries, on a custom path.
