### PR TITLE
Add binaries to %if statement for nodna

### DIFF
--- a/package/rpm/pfring.spec.in
+++ b/package/rpm/pfring.spec.in
@@ -92,14 +92,14 @@ rm -fr $RPM_BUILD_ROOT
 %if %nodna == 0
 /usr/local/bin/pfdnabounce
 /usr/local/bin/pfdnacluster_master
-%endif
-#/usr/local/bin/tcpdump
-/usr/local/bin/pfcount
-/usr/local/bin/pfsend
 /usr/local/bin/zbalance_ipc
 /usr/local/bin/zsend
 /usr/local/bin/zcount
 /usr/local/bin/zcount_ipc
+%endif
+#/usr/local/bin/tcpdump
+/usr/local/bin/pfcount
+/usr/local/bin/pfsend
 /usr/local/pfring/README.FIRST
 /usr/local/pfring/README-DAQ.1st
 /etc/init.d/pf_ring


### PR DESCRIPTION
The package build process fails if nodna is set to 1 in the build-rpm section of the Makefile:

```
Processing files: pfring-6.3.0-435.x86_64
error: File not found: /opt/critical-stack/rpmbuild/BUILDROOT/pfring-6.3.0-435.x86_64/usr/local/bin/zbalance_ipc
error: File not found: /opt/critical-stack/rpmbuild/BUILDROOT/pfring-6.3.0-435.x86_64/usr/local/bin/zsend
error: File not found: /opt/critical-stack/rpmbuild/BUILDROOT/pfring-6.3.0-435.x86_64/usr/local/bin/zcount
error: File not found: /opt/critical-stack/rpmbuild/BUILDROOT/pfring-6.3.0-435.x86_64/usr/local/bin/zcount_ipc


RPM build errors:
    File not found: /opt/critical-stack/rpmbuild/BUILDROOT/pfring-6.3.0-435.x86_64/usr/local/bin/zbalance_ipc
    File not found: /opt/critical-stack/rpmbuild/BUILDROOT/pfring-6.3.0-435.x86_64/usr/local/bin/zsend
    File not found: /opt/critical-stack/rpmbuild/BUILDROOT/pfring-6.3.0-435.x86_64/usr/local/bin/zcount
    File not found: /opt/critical-stack/rpmbuild/BUILDROOT/pfring-6.3.0-435.x86_64/usr/local/bin/zcount_ipc
make: *** [build-rpm] Error 1
```
