### PR TITLE
Fix BPF inversion on Linux 4.4.x kernels

### DIFF
--- a/kernel/pf_ring.c
+++ b/kernel/pf_ring.c
@@ -3978,7 +3978,7 @@ int bpf_filter_skb(struct sk_buff *skb,
 #elif(LINUX_VERSION_CODE < KERNEL_VERSION(3,0,0))
     res = sk_run_filter(skb, filter->insns);
 #elif(LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0))
-    res = sk_filter(pfr->sk, skb);;
+    res = (sk_filter(pfr->sk, skb) == 0) ? 1 : 0;
 #else
     res = SK_RUN_FILTER(filter, skb);
 #endif


### PR DESCRIPTION
Linux sk_filter returns 0 if packet should be accepted and -EPERM
if the packet should be dropped. This leads into a situation where
current code causes all BPF filters to be inverse.

This commit fixes the inversion by setting res to 1 if sk_filter
yields an "accepted result", otherwise set res to 0.
