### PR TITLE
when reader is slower than writer, buffer overwrite

### DIFF
--- a/kernel/pf_ring.c
+++ b/kernel/pf_ring.c
@@ -883,7 +883,7 @@ static inline int check_free_ring_slot(struct pf_ring_socket *pfr)
       */
 
       /* Zero-copy recv: this prevents from overwriting packets while apps are processing them */
-      if((pfr->slots_info->tot_mem - sizeof(FlowSlotInfo) - pfr->slots_info->insert_off) < (2 * pfr->slots_info->slot_len) &&
+      if((pfr->slots_info->tot_mem - sizeof(FlowSlotInfo) - pfr->slots_info->insert_off) < (3 * pfr->slots_info->slot_len) &&
 	 remove_off == 0)
 	return(0);
     }


### PR DESCRIPTION
Consider the following situation, A and B is slot_len exactly
## 1.  write A

when insert_off = tot_mem - sizeof(FlowSlotInfo) - 1.9 \* slot_len , and we simply represent insert_off as -1.9 

so insert is permit,  insert_off += slot_len, but insert_off no room for one another slot, then reset insert_off = 0.  write A in block [-1.9, -0.9)
## 2.  read A

pfring_recv() read A, then advance remove_off to 0 from -1.9.   And block A [-1.9, -0.9) is used by userland program.
## 3. write B overlap with A

when userland reader is slower than writer,  and insert_off  at  (-3, -2) , we assume insert_off as -2.1 simply.

Now remove_off is 0 and  2 \* slot_len < tot_mem - sizeof(FlowSlotInfo) - insert_off = 2.1  , So write B is permit.
  advance insert_off to -1.1, and write B in block [-2.1, -1.1).  

Apparently B overwrite partial memory of A which is being processed by userland program.
