### PR TITLE
note on ntanl version requerments

### DIFF
--- a/doc/README.napatech
+++ b/doc/README.napatech
@@ -3,6 +3,10 @@ Napatech support in PF_RING
 
 Prerequisite: Napatech drivers and SDK installed.
 
+As of PF_RING 6.2 you need ntanl v.4.0.1 and 
+with ntanl 3.2 being what normal support provides this vershion of 
+PF_RING may not work for you 
+
 PF_RING has native support for Napatech adapters, the Napatech library
 needs to be installed (under /opt/napatech3) in order to enable the 
 Napatech module when configuring/compiling the pf_ring library.


### PR DESCRIPTION
ntanl 3.2 is what support provides but PF_RING >= 6.2 needs ntanl 4.0.1
