### PR TITLE
Simple and useful change to implement TCP flags filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,5 +129,39 @@ userland/lib/libpfring.so
 !/Makefile
 !/.pc/
 
-# Use "git clean -ndX" to test
 
+drivers/intel/i40e/i40e-1.5.18-zc/src/i40e/Module.symvers
+drivers/intel/i40e/i40e-1.5.18-zc/src/i40e/i40e.mod.c
+drivers/intel/i40e/i40e-1.5.18-zc/src/i40e/modules.order
+userland/c++/Makefile
+userland/examples/Makefile
+userland/examples_zc/Makefile
+userland/examples_zc/zsanitycheck
+userland/lib/Makefile
+userland/lib/nbpf.h
+userland/lib/npcap.h
+userland/lib/pfring_mod_dag.h
+userland/lib/pfring_mod_myricom.h
+userland/lib/pfring_mod_nt.h
+userland/lib/pfring_mod_timeline.h
+userland/libpcap-1.7.4/Makefile
+userland/libpcap-1.7.4/bpf_filter.c
+userland/libpcap-1.7.4/config.h
+userland/libpcap-1.7.4/grammar.c
+userland/libpcap-1.7.4/libpcap.a
+userland/libpcap-1.7.4/libpcap.so.1.7.4
+userland/libpcap-1.7.4/net
+userland/libpcap-1.7.4/pcap-config
+userland/libpcap-1.7.4/scanner.c
+userland/libpcap-1.7.4/scanner.h
+userland/libpcap-1.7.4/tokdefs.h
+userland/libpcap-1.7.4/version.c
+userland/libpcap-1.7.4/version.h
+userland/nbpf/Makefile
+userland/nbpf/grammar.tab.c
+userland/nbpf/grammar.tab.h
+userland/nbpf/lex.yy.c
+userland/nbpf/libnbpf.a
+userland/nbpf/nbpftest
+
+# Use "git clean -ndX" to test

--- a/kernel/linux/pf_ring.h
+++ b/kernel/linux/pf_ring.h
@@ -369,6 +369,10 @@ typedef struct {
   ip_addr   shost_mask, dhost_mask;    /* IPv4/6 network mask */
   u_int16_t sport_low, sport_high;     /* All ports between port_low...port_high means 'any' port */
   u_int16_t dport_low, dport_high;     /* All ports between port_low...port_high means 'any' port */
+  struct {
+    u_int8_t flags;             /* TCP flags (0 if not available) */
+    u_int32_t seq_num, ack_num; /* TCP sequence number */
+  } tcp;
 } filtering_rule_core_fields;
 
 /* ************************************************* */

--- a/kernel/linux/pf_ring.h
+++ b/kernel/linux/pf_ring.h
@@ -371,7 +371,6 @@ typedef struct {
   u_int16_t dport_low, dport_high;     /* All ports between port_low...port_high means 'any' port */
   struct {
     u_int8_t flags;             /* TCP flags (0 if not available) */
-    u_int32_t seq_num, ack_num; /* TCP sequence number */
   } tcp;
 } filtering_rule_core_fields;
 

--- a/kernel/pf_ring.c
+++ b/kernel/pf_ring.c
@@ -2441,6 +2441,10 @@ static int match_filtering_rule(struct pf_ring_socket *pfr,
 
   *behaviour = rule->rule.rule_action;
 
+  if((hdr->extended_hdr.parsed_pkt.l3_proto == IPPROTO_TCP)
+     && ((hdr->extended_hdr.parsed_pkt.tcp.flags & rule->rule.core_fields.tcp.flags) != rule->rule.core_fields.tcp.flags))
+    return(0);
+
   if((rule->rule.core_fields.if_index > 0)
      && (hdr->extended_hdr.if_index != UNKNOWN_INTERFACE) 
      && (hdr->extended_hdr.if_index != rule->rule.core_fields.if_index))


### PR DESCRIPTION
Hi all,

I suggest these few lines in pf_ring.c and pf_ring.h to implement TCP flags filtering.

It is very useful when is needed to select just SYN and FIN pkts, for example.

Thank you in advance.

regards,

Paulo Angelo
