### PR TITLE
add current ring version to module info

### DIFF
--- a/kernel/pf_ring.c
+++ b/kernel/pf_ring.c
@@ -8391,5 +8391,6 @@ module_exit(ring_exit);
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("ntop.org");
 MODULE_DESCRIPTION("Packet capture acceleration and analysis");
+MODULE_VERSION(RING_VERSION);
 
 MODULE_ALIAS_NETPROTO(PF_RING);


### PR DESCRIPTION
this would ease version handling a lot (for me).
is there anything that speaks against adding the pf-ring version to the module info?