### PR TITLE
Update trans_start bits to compile under 4.7.5

### DIFF
--- a/drivers/intel/e1000e/e1000e-3.2.7.1-zc/src/netdev.c
+++ b/drivers/intel/e1000e/e1000e-3.2.7.1-zc/src/netdev.c
@@ -259,7 +259,11 @@ static void e1000e_dump(struct e1000_adapter *adapter)
 		dev_info(pci_dev_to_dev(adapter->pdev), "Net device Info\n");
 		pr_info("Device Name     state            trans_start      last_rx\n");
 		pr_info("%-15s %016lX %016lX %016lX\n", netdev->name,
+#if(LINUX_VERSION_CODE >= KERNEL_VERSION(4,7,0))
+			netdev->state, dev_trans_start(netdev), netdev->last_rx);
+#else
 			netdev->state, netdev->trans_start, netdev->last_rx);
+#endif
 	}
 
 	/* Print Registers */
@@ -7006,7 +7010,11 @@ static netdev_tx_t e1000_xmit_frame(struct sk_buff *skb,
 		tx_ring->buffer_info[first].time_stamp = 0;
 		tx_ring->next_to_use = first;
 	}
+#if(LINUX_VERSION_CODE >= KERNEL_VERSION(4,7,0))
+	netif_trans_update(netdev);
+#else
 	netdev->trans_start = jiffies;
+#endif
 
 	return NETDEV_TX_OK;
 }

--- a/drivers/intel/fm10k/fm10k-0.20.1-zc/src/fm10k_main.c
+++ b/drivers/intel/fm10k/fm10k-0.20.1-zc/src/fm10k_main.c
@@ -256,7 +256,11 @@ static bool fm10k_can_reuse_rx_page(struct fm10k_rx_buffer *rx_buffer,
 	/* Even if we own the page, we are not allowed to use atomic_set()
 	 * This would break get_page_unless_zero() users.
 	 */
+#if(LINUX_VERSION_CODE >= KERNEL_VERSION(4,7,0))
+	atomic_inc(&page->_mapcount);
+#else
 	atomic_inc(&page->_count);
+#endif
 
 	return true;
 }

--- a/drivers/intel/fm10k/fm10k-0.20.1-zc/src/fm10k_main.c
+++ b/drivers/intel/fm10k/fm10k-0.20.1-zc/src/fm10k_main.c
@@ -257,7 +257,7 @@ static bool fm10k_can_reuse_rx_page(struct fm10k_rx_buffer *rx_buffer,
 	 * This would break get_page_unless_zero() users.
 	 */
 #if(LINUX_VERSION_CODE >= KERNEL_VERSION(4,7,0))
-	atomic_inc(&page->_mapcount);
+	page_ref_inc(page);
 #else
 	atomic_inc(&page->_count);
 #endif

--- a/drivers/intel/fm10k/fm10k-0.20.1-zc/src/fm10k_pci.c
+++ b/drivers/intel/fm10k/fm10k-0.20.1-zc/src/fm10k_pci.c
@@ -146,7 +146,11 @@ static void fm10k_reinit(struct fm10k_intfc *interface)
 	WARN_ON(in_interrupt());
 
 	/* put off any impending NetWatchDogTimeout */
+#if(LINUX_VERSION_CODE >= KERNEL_VERSION(4,7,0))
+	netif_trans_update(netdev);
+#else
 	netdev->trans_start = jiffies;
+#endif
 
 	while (test_and_set_bit(__FM10K_RESETTING, &interface->state))
 		usleep_range(1000, 2000);

--- a/drivers/intel/i40e/i40e-1.5.18-zc/src/i40e/i40e_main.c
+++ b/drivers/intel/i40e/i40e-1.5.18-zc/src/i40e/i40e_main.c
@@ -295,7 +295,11 @@ static void i40e_tx_timeout(struct net_device *netdev)
 		unsigned long trans_start;
 
 		q = netdev_get_tx_queue(netdev, i);
+#if(LINUX_VERSION_CODE >= KERNEL_VERSION(4,7,0))
+		trans_start = q->trans_start ? : dev_trans_start(netdev);
+#else
 		trans_start = q->trans_start ? : netdev->trans_start;
+#endif
 		if (netif_xmit_stopped(q) && time_after(jiffies,
 			(trans_start + netdev->watchdog_timeo))) {
 			hung_queue = i;

--- a/drivers/intel/igb/igb-5.3.3.5-zc/src/igb_ptp.c
+++ b/drivers/intel/igb/igb-5.3.3.5-zc/src/igb_ptp.c
@@ -30,6 +30,7 @@
 #include "igb.h"
 
 #ifdef HAVE_PTP_1588_CLOCK
+#include <linux/clocksource.h>
 #include <linux/module.h>
 #include <linux/device.h>
 #include <linux/pci.h>

--- a/drivers/intel/ixgbe/ixgbe-4.1.5-zc/src/ixgbe_main.c
+++ b/drivers/intel/ixgbe/ixgbe-4.1.5-zc/src/ixgbe_main.c
@@ -6298,7 +6298,11 @@ void ixgbe_reinit_locked(struct ixgbe_adapter *adapter)
 {
 	WARN_ON(in_interrupt());
 	/* put off any impending NetWatchDogTimeout */
+#if(LINUX_VERSION_CODE >= KERNEL_VERSION(4,7,0))
+	netif_trans_update(adapter->netdev);
+#else
 	adapter->netdev->trans_start = jiffies;
+#endif
 
 	while (test_and_set_bit(__IXGBE_RESETTING, &adapter->state))
 		usleep_range(1000, 2000);

--- a/drivers/intel/ixgbe/ixgbe-4.1.5-zc/src/ixgbe_ptp.c
+++ b/drivers/intel/ixgbe/ixgbe-4.1.5-zc/src/ixgbe_ptp.c
@@ -23,6 +23,8 @@
 *******************************************************************************/
 
 #include "ixgbe.h"
+
+#include <linux/clocksource.h>
 #include <linux/ptp_classify.h>
 
 /*


### PR DESCRIPTION
Per http://lists.openwall.net/netdev/2016/05/03/87:
1. Replace read-accesses:
  x = dev->trans_start

  gets replaced by
  x = dev_trans_start(dev)

2. Replace write accesses:
  dev->trans_start = jiffies;

  gets replaced with new helper:
  netif_trans_update(dev);

3. This helper is then changed to set
   netdev_get_tx_queue(dev, 0)->trans_start
   instead of dev->trans_start.

Also include linux/clocksource.h for CLOCKSOURCE_MASK macro