### PR TITLE
166: call hash_pkt_header after parse offl. vlan

### DIFF
--- a/kernel/pf_ring.c
+++ b/kernel/pf_ring.c
@@ -2293,8 +2293,10 @@ static int parse_pkt(struct sk_buff *skb,
   rc = parse_raw_pkt(buffer, data_len, hdr, ip_id);
 
   if (!hdr->extended_hdr.parsed_pkt.vlan_id) { /* check for stripped vlan id */
-    if (__vlan_hwaccel_get_tag(skb, &hdr->extended_hdr.parsed_pkt.vlan_id) == 0)
+    if (__vlan_hwaccel_get_tag(skb, &hdr->extended_hdr.parsed_pkt.vlan_id) == 0) {
       hdr->extended_hdr.parsed_pkt.vlan_id &= VLAN_VID_MASK;
+      hash_pkt_header(hdr, HASH_PKT_HDR_RECOMPUTE); /* force hash recomputation */
+    }
   }
 
   return(rc);


### PR DESCRIPTION
in a VLAN offload scenario we will not have the vlan header present in the
buffer we give to parse_pkt.
We manually parse the vlan by calling function __vlan_hwaccel_get_tag and
setting hdr->extended_hdr.parsed_pkt.vlan_id to its result.
However, we do not call hash_pkt_header after this modification of the header.
This commit will invoke hash_pkt_header with the flag HASH_PKT_HDR_RECOMPUTE in
order to force hash recomputation.