### PR TITLE
Bug fix while cross compile for x86_64 platform

### DIFF
--- a/userland/configure
+++ b/userland/configure
@@ -3390,10 +3390,10 @@ fi
 if test "$IS_FREEBSD" != "1"; then
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking if r/w locks are supported" >&5
 $as_echo_n "checking if r/w locks are supported... " >&6; }
-if test "$cross_compiling" = yes; then :
+if test "$cross_compiling" = yes -a "${target_alias:0:6}" != "x86_64"; then :
   { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
 $as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error $? "cannot run test program while cross compiling
+as_fn_error $? "cannot run test program while cross compiling for ${target_alias} target
 See \`config.log' for more details" "$LINENO" 5; }
 else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext

--- a/userland/lib/pfring.c
+++ b/userland/lib/pfring.c
@@ -16,7 +16,7 @@
 #include <pthread.h>
 
 #ifndef _NETINET_IF_ETHER_H
-#define _NETINET_IF_ETHER_H 1
+#define _NETINET_IF_ETHER_H /* fixes compilation with musl library */
 #endif
 
 #include "pfring.h"
@@ -1322,4 +1322,3 @@ void pfring_freealldevs(pfring_if_t *list) {
 }
 
 /* **************************************************** */
-

--- a/userland/lib/pfring.c
+++ b/userland/lib/pfring.c
@@ -15,6 +15,10 @@
 #include <sys/types.h>
 #include <pthread.h>
 
+#ifndef _NETINET_IF_ETHER_H
+#define _NETINET_IF_ETHER_H 1
+#endif
+
 #include "pfring.h"
 #include <net/ethernet.h>
 


### PR DESCRIPTION
Hi,
    I am porting libpfring to lede/openwrt, this PR can fix some compilation error.

SDK :  lede-latest
SDK git repository:  https://github.com/lede-project/source

PR for openwrt/lede:
https://github.com/openwrt/packages/pull/4055