### PR TITLE
replace sys/poll.h with poll.h

### DIFF
--- a/userland/examples/pcount.c
+++ b/userland/examples/pcount.c
@@ -38,7 +38,7 @@ struct pcap_stat pcapStats;
 #include <unistd.h>
 #include <sys/mman.h>
 #include <errno.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <time.h>
 #include <netinet/in_systm.h>
 #include <netinet/in.h>

--- a/userland/examples/pfbridge.c
+++ b/userland/examples/pfbridge.c
@@ -30,7 +30,7 @@
 #include <unistd.h>
 #include <sys/mman.h>
 #include <errno.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <sys/time.h>
 #include <time.h>
 #include <sys/socket.h>

--- a/userland/examples/pfcount.c
+++ b/userland/examples/pfcount.c
@@ -30,7 +30,7 @@
 #include <unistd.h>
 #include <sys/mman.h>
 #include <errno.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <netinet/in_systm.h>
 #include <netinet/in.h>
 #include <netinet/ip.h>

--- a/userland/examples/pfcount_82599.c
+++ b/userland/examples/pfcount_82599.c
@@ -30,7 +30,7 @@
 #include <unistd.h>
 #include <sys/mman.h>
 #include <errno.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <netinet/in_systm.h>
 #include <netinet/in.h>
 #include <netinet/ip.h>

--- a/userland/examples/pfcount_multichannel.c
+++ b/userland/examples/pfcount_multichannel.c
@@ -30,7 +30,7 @@
 #include <unistd.h>
 #include <sys/mman.h>
 #include <errno.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <netinet/in_systm.h>
 #include <netinet/in.h>
 #include <netinet/ip.h>

--- a/userland/examples/pflatency.c
+++ b/userland/examples/pflatency.c
@@ -30,7 +30,7 @@
 #include <unistd.h>
 #include <sys/mman.h>
 #include <errno.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <netinet/in_systm.h>
 #include <netinet/in.h>
 #include <netinet/ip.h>

--- a/userland/examples/pfsystest.c
+++ b/userland/examples/pfsystest.c
@@ -30,7 +30,7 @@
 #include <unistd.h>
 #include <sys/mman.h>
 #include <errno.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <netinet/in_systm.h>
 #include <netinet/in.h>
 #include <netinet/ip.h>

--- a/userland/examples/pfwrite.c
+++ b/userland/examples/pfwrite.c
@@ -45,7 +45,7 @@
 #include <unistd.h>
 #include <sys/mman.h>
 #include <errno.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <time.h>
 #include <netinet/in_systm.h>
 #include <netinet/in.h>

--- a/userland/examples/preflect.c
+++ b/userland/examples/preflect.c
@@ -38,7 +38,7 @@ struct pcap_stat pcapStats;
 #include <unistd.h>
 #include <sys/mman.h>
 #include <errno.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <time.h>
 #include <netinet/in_systm.h>
 #include <netinet/in.h>

--- a/userland/lib/pfring.h
+++ b/userland/lib/pfring.h
@@ -37,7 +37,7 @@
 #include <unistd.h>
 #include <sys/mman.h>
 #include <errno.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <sys/socket.h>
 #include <linux/sockios.h>
 #endif


### PR DESCRIPTION
POSIX specifies that <poll.h> is the correct header to include for
poll(),whereas <sys/poll.h> is only needed for ancient glibc (<2.3), so
let's follow POSIX instead.

As a side-effect, this silences a warnings when compiling against the
musl C-library:
    In file included from pfring.h:40:0,
                     from pfring.c:22:
    musl-xxx/include/sys/poll.h:1:2:
    warning: #warning redirecting incorrect
    #include <sys/poll.h> to <poll.h> [-Wcpp]
    #warning redirecting incorrect #include
    <sys/poll.h> to <poll.h>
etc.

visit below for more details:

https://svn.boost.org/trac/boost/ticket/12419

Signed-off-by: BangLang Huang <banglang.huang@foxmail.com>