### PR TITLE
Added note to hugepages doc

### DIFF
--- a/doc/README.hugepages.md
+++ b/doc/README.hugepages.md
@@ -5,9 +5,11 @@ how to enable them into your system.
 
 ## For the impatient
 ```
-echo 1024 > /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
+echo 1024 > /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages # 1024*2048kB = ~2.1 GB
 mount -t hugetlbfs nodev /dev/hugepages
 ```
+
+_Warning: If you accidentally exceed the amount of available RAM, the kernel will round down to the highest number of hugepages possible and grind your system to a halt._
 
 ## The whole story
 Linux typically use memory pages of 4 KBytes, but provides an explicit 


### PR DESCRIPTION
Being impatient, I blindly copy pasted the `1024*2048kB` hugepages setting without noticing the note at the bottom that the kernel allows you to set it to a stupidly high amount and rounds it down silently.

Complete PEBKAC bug, but at least it's a bit harder to miss now. =) 