### PR TITLE
Adding soname to the shared library per Gentoo QA.

### DIFF
--- a/userland/lib/Makefile.in
+++ b/userland/lib/Makefile.in
@@ -110,7 +110,7 @@ ${STATICLIB}: Makefile extract_nbpf @PF_RING_ZC_DEP@ @NT_DEP@ @MYRICOM_DEP@ @DAG
 
 ${DYNAMICLIB}: ${OBJS} extract_nbpf @PF_RING_ZC_DEP@ @NT_DEP@ @MYRICOM_DEP@ @DAG_DEP@ @FIBERBLAZE_DEP@ @ACCOLADE_DEP@ @NPCAP_DEP@ pfring.h ${RING_H} Makefile
 	@echo "=*= making library $@ =*="
-	${CC} ${LDFLAGS} ${OBJS} ${NBPF_OBJS} ${SYSLIBS} -o $@
+	${CC} -Wl,-soname,$@.1 ${LDFLAGS} ${OBJS} ${NBPF_OBJS} ${SYSLIBS} -o $@
 
 extract_pfring_zc_lib:
 	@AR_X@ @PF_RING_ZC_LIB@


### PR DESCRIPTION
See https://dev.gentoo.org/~zmedico/portage/doc/ch07s04.html

I am not sure this is the best way, I see way more code in libpcap, but it is the minimal at least. When we have further versions, it will need to change (unless somebody can rewrite it now).