### PR TITLE
userland-configure: fix cross compilation for r/w locks

### DIFF
--- a/userland/configure
+++ b/userland/configure
@@ -3727,12 +3727,6 @@ fi
 if test "$IS_FREEBSD" != "1"; then
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking if r/w locks are supported" >&5
 $as_echo_n "checking if r/w locks are supported... " >&6; }
-  if test "$cross_compiling" = yes; then :
-  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error $? "cannot run test program while cross compiling
-See \`config.log' for more details" "$LINENO" 5; }
-else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -3745,7 +3739,7 @@ else
 
 
 _ACEOF
-if ac_fn_c_try_run "$LINENO"; then :
+if ac_fn_c_try_compile "$LINENO"; then :
    { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
 cat >>confdefs.h <<_ACEOF
@@ -3759,7 +3753,6 @@ $as_echo "no" >&6; }
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
   conftest.$ac_objext conftest.beam conftest.$ac_ext
-fi
 
 fi
 


### PR DESCRIPTION
  use compilation test rather than running test
  for pthread and r/w locks.

 ( cross compilation environment:  https://github.com/openwrt/packages/pull/4055 )

Signed-off-by: BangLang Huang <banglang.huang@foxmail.com>