### PR TITLE
Fix i40e num_lan_msix calculation when number of cpus is greater than rss

### DIFF
--- a/drivers/intel/i40e/i40e-2.0.26-zc/src/i40e/i40e_main.c
+++ b/drivers/intel/i40e/i40e-2.0.26-zc/src/i40e/i40e_main.c
@@ -8835,6 +8835,10 @@ static int i40e_init_msix(struct i40e_pf *pf)
 	 * zero.
 	 */
 	extra_vectors = min_t(int, cpus - pf->num_lan_msix, vectors_left);
+#ifdef HAVE_PF_RING
+	if (RSS[pf->instance] != 0)
+		extra_vectors = min_t(int, extra_vectors, RSS[pf->instance] - pf->num_lan_msix);
+#endif
 	pf->num_lan_msix += extra_vectors;
 	vectors_left -= extra_vectors;
 


### PR DESCRIPTION
If extra_vectors is not adjusted there will be more q_vectors than
allocated queue pairs which will lead to a panic in i40e_vsi_map_rings_to_vectors

Panic seen on a machine with 56 cores and i40e.ko loaded with RSS=10
Panic is similar to the one in issue 277