### PR TITLE
Fix error when cross compilation

### DIFF
--- a/userland/configure
+++ b/userland/configure
@@ -3295,7 +3295,9 @@ fi
 done
 
 
-MACHINE=`uname -m`
+if test -z "$MACHINE"; then
+  MACHINE=`uname -m`
+fi
 CFLAGS=""
 SYS_LIBS=""
 

--- a/userland/configure
+++ b/userland/configure
@@ -3301,7 +3301,7 @@ fi
 CFLAGS=""
 SYS_LIBS=""
 
-NATIVE=`$CC -c -Q -march=native --help=target| grep "march" | xargs | cut -d ' ' -f 2`
+NATIVE=`$CC -c -Q --help=target| grep "march" | xargs | cut -d ' ' -f 2`
 if test -f "lib/libs/libpfring_zc_x86_64_$NATIVE.a"; then
   CFLAGS="-march=native -mtune=native $CFLAGS"
   LIBARCH="_$NATIVE"


### PR DESCRIPTION
2f49f67  : userland: allow specify MACHINE value by user
 
 This commit Allow user to set the machine type on their own,
  Once the MACHINE variable is not set, use 'uname -m'
  by default.

bf64609 : userland: fix error on configuration for non-x86 target

This commit can fix the configuration error when cross
compile for non-x86 target, below is the error log on
arm relevant platform.

...
cc1: error: unrecognized argument in option '-march=native'
cc1: note: valid arguments to '-march=' are: armv2 armv2a \
    armv3 armv3m armv4 armv4t armv5 armv5e armv5t armv5te \
        armv6 armv6-m armv6j armv6k armv6s-m armv6t2 armv6z \
        armv6zk armv7 armv7-a armv7-m armv7-r armv7e-m \
        armv7ve armv8-a armv8-a+crc iwmmxt iwmmxt2 **native**
...
