### PR TITLE
Clean up makefiles and other stuff to make packaging easier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,9 @@ install:
 	cd userland; make install
 
 clean:
-	cd kernel; make clean
-	cd userland; make clean
-	cd drivers; make clean
+	-cd kernel; make clean
+	-cd userland; make clean
+	-cd drivers; make clean
 	-cd userland/snort/pfring-daq-module; make clean
 
 snort:

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ all:
 	cd userland; make
 	cd drivers; make
 
+install:
+	cd userland; make install
+
 clean:
 	cd kernel; make clean
 	cd userland; make clean

--- a/drivers/intel/Makefile
+++ b/drivers/intel/Makefile
@@ -5,6 +5,8 @@ IXGBE=ixgbe/ixgbe-5.0.4-zc
 I40E=i40e/i40e-2.3.6-zc
 FM10K=fm10k/fm10k-0.20.1-zc
 
+export C_INCLUDE_PATH := $(shell cd ../../kernel/linux; pwd)
+
 all:
 #	cd $(E1000)/src; make
 	cd $(E1000E)/src; make

--- a/drivers/intel/Makefile.dkms.e1000e.in
+++ b/drivers/intel/Makefile.dkms.e1000e.in
@@ -5,8 +5,6 @@ add: veryclean
 	mkdir /usr/src/@E1000E@-zc-@E1000E_VERSION@.@REVISION@
 	cd @E1000E@/@E1000E@-@E1000E_VERSION@-zc/src ; make clean; cp -r * /usr/src/@E1000E@-zc-@E1000E_VERSION@.@REVISION@
 	cd @E1000E@/@E1000E@-@E1000E_VERSION@-zc/src ; cp ../../../../../kernel/linux/pf_ring.h /usr/src/@E1000E@-zc-@E1000E_VERSION@.@REVISION@
-	sed -i -e 's|../../../../../kernel/linux/pf_ring.h|pf_ring.h|g' /usr/src/@E1000E@-zc-@E1000E_VERSION@.@REVISION@/*.c
-	sed -i -e 's|../../../../../kernel/linux/pf_ring.h|pf_ring.h|g' /usr/src/@E1000E@-zc-@E1000E_VERSION@.@REVISION@/*.h
 	#sed -i -e 's|DRIVER_NAME = @E1000E@|DRIVER_NAME = @E1000E@_zc|g' /usr/src/@E1000E@-zc-@E1000E_VERSION@.@REVISION@/Makefile
 	sed -i '/EXTRA_CFLAGS += -DDRIVER_\$$/a DRIVER_NAME=@E1000E@_zc' /usr/src/@E1000E@-zc-@E1000E_VERSION@.@REVISION@/Makefile
 	cp dkms.conf.@E1000E@ /usr/src/@E1000E@-zc-@E1000E_VERSION@.@REVISION@/dkms.conf

--- a/drivers/intel/Makefile.dkms.fm10k.in
+++ b/drivers/intel/Makefile.dkms.fm10k.in
@@ -6,8 +6,6 @@ add: veryclean
 	cd @FM10K@/@FM10K@-@FM10K_VERSION@-zc/src/ ; make clean; cp -r * /usr/src/@FM10K@-zc-@FM10K_VERSION@.@REVISION@/
 	cd @FM10K@/@FM10K@-@FM10K_VERSION@-zc/src/ ; cp ../../../../../kernel/linux/pf_ring.h /usr/src/@FM10K@-zc-@FM10K_VERSION@.@REVISION@/
 	cd @FM10K@/@FM10K@-@FM10K_VERSION@-zc/src/ ; cp Makefile /usr/src/@FM10K@-zc-@FM10K_VERSION@.@REVISION@/
-	sed -i -e 's|../../../../../kernel/linux/pf_ring.h|pf_ring.h|g' /usr/src/@FM10K@-zc-@FM10K_VERSION@.@REVISION@/*.c
-	sed -i -e 's|../../../../../kernel/linux/pf_ring.h|pf_ring.h|g' /usr/src/@FM10K@-zc-@FM10K_VERSION@.@REVISION@/*.h
 	sed -i -e 's/fm10k\.o/fm10k_zc.o/' -e 's/fm10k-/fm10k_zc-/' /usr/src/@FM10K@-zc-@FM10K_VERSION@.@REVISION@/Kbuild
 	cp dkms.conf.@FM10K@ /usr/src/@FM10K@-zc-@FM10K_VERSION@.@REVISION@/dkms.conf 
 	mv /usr/src/fm10k-zc-@FM10K_VERSION@.@REVISION@/Kbuild /usr/src/fm10k-zc-@FM10K_VERSION@.@REVISION@/Makefile

--- a/drivers/intel/Makefile.dkms.i40e.in
+++ b/drivers/intel/Makefile.dkms.i40e.in
@@ -6,8 +6,6 @@ add: veryclean
 	cd @I40E@/@I40E@-@I40E_VERSION@-zc/src/ ; make clean; cp -r i40e/* /usr/src/@I40E@-zc-@I40E_VERSION@.@REVISION@/i40e_zc/
 	cd @I40E@/@I40E@-@I40E_VERSION@-zc/src/i40e/ ; cp ../../../../../../kernel/linux/pf_ring.h /usr/src/@I40E@-zc-@I40E_VERSION@.@REVISION@/i40e_zc/
 	cd @I40E@/@I40E@-@I40E_VERSION@-zc/src/ ; cp Makefile /usr/src/@I40E@-zc-@I40E_VERSION@.@REVISION@/
-	sed -i -e 's|../../../../../../kernel/linux/pf_ring.h|pf_ring.h|g' /usr/src/@I40E@-zc-@I40E_VERSION@.@REVISION@/i40e_zc/*.c
-	sed -i -e 's|../../../../../../kernel/linux/pf_ring.h|pf_ring.h|g' /usr/src/@I40E@-zc-@I40E_VERSION@.@REVISION@/i40e_zc/*.h
 	sed -i -e 's/i40e\.o/i40e_zc.o/' -e 's/i40e-/i40e_zc-/' /usr/src/@I40E@-zc-@I40E_VERSION@.@REVISION@/i40e_zc/Kbuild
 	cp dkms.conf.@I40E@ /usr/src/@I40E@-zc-@I40E_VERSION@.@REVISION@/dkms.conf 
 	dkms add -m @I40E@-zc -v @I40E_VERSION@.@REVISION@

--- a/drivers/intel/Makefile.dkms.igb.in
+++ b/drivers/intel/Makefile.dkms.igb.in
@@ -5,8 +5,6 @@ add: remove
 	mkdir /usr/src/@IGB@-zc-@IGB_VERSION@.@REVISION@
 	cd @IGB@/@IGB@-@IGB_VERSION@-zc/src ; make clean; cp -r * /usr/src/@IGB@-zc-@IGB_VERSION@.@REVISION@
 	cd @IGB@/@IGB@-@IGB_VERSION@-zc/src ; cp ../../../../../kernel/linux/pf_ring.h /usr/src/@IGB@-zc-@IGB_VERSION@.@REVISION@
-	sed -i -e 's|../../../../../kernel/linux/pf_ring.h|pf_ring.h|g' /usr/src/@IGB@-zc-@IGB_VERSION@.@REVISION@/*.c
-	sed -i -e 's|../../../../../kernel/linux/pf_ring.h|pf_ring.h|g' /usr/src/@IGB@-zc-@IGB_VERSION@.@REVISION@/*.h
 	#sed -i -e 's|DRIVER_NAME=@IGB@|DRIVER_NAME=@IGB@_zc|g' /usr/src/@IGB@-zc-@IGB_VERSION@.@REVISION@/Makefile
 	sed -i '/EXTRA_CFLAGS += -DDRIVER_\$$/a DRIVER_NAME=@IGB@_zc' /usr/src/@IGB@-zc-@IGB_VERSION@.@REVISION@/Makefile
 	cp dkms.conf.@IGB@ /usr/src/@IGB@-zc-@IGB_VERSION@.@REVISION@/dkms.conf

--- a/drivers/intel/Makefile.dkms.ixgbe.in
+++ b/drivers/intel/Makefile.dkms.ixgbe.in
@@ -5,8 +5,6 @@ add: veryclean
 	mkdir /usr/src/@IXGBE@-zc-@IXGBE_VERSION@.@REVISION@
 	cd @IXGBE@/@IXGBE@-@IXGBE_VERSION@-zc/src ; make clean; cp -r * /usr/src/@IXGBE@-zc-@IXGBE_VERSION@.@REVISION@
 	cd @IXGBE@/@IXGBE@-@IXGBE_VERSION@-zc/src ; cp ../../../../../kernel/linux/pf_ring.h /usr/src/@IXGBE@-zc-@IXGBE_VERSION@.@REVISION@
-	sed -i -e 's|../../../../../kernel/linux/pf_ring.h|pf_ring.h|g' /usr/src/@IXGBE@-zc-@IXGBE_VERSION@.@REVISION@/*.c
-	sed -i -e 's|../../../../../kernel/linux/pf_ring.h|pf_ring.h|g' /usr/src/@IXGBE@-zc-@IXGBE_VERSION@.@REVISION@/*.h
 	#sed -i -e 's|DRIVER_NAME=@IXGBE@|DRIVER_NAME=@IXGBE@_zc|g' /usr/src/@IXGBE@-zc-@IXGBE_VERSION@.@REVISION@/Makefile
 	sed -i '/EXTRA_CFLAGS += -DDRIVER_\$$/a DRIVER_NAME=@IXGBE@_zc' /usr/src/@IXGBE@-zc-@IXGBE_VERSION@.@REVISION@/Makefile
 	cp dkms.conf.@IXGBE@ /usr/src/@IXGBE@-zc-@IXGBE_VERSION@.@REVISION@/dkms.conf 

--- a/drivers/intel/e1000e/e1000e-3.2.7.1-zc/src/netdev.c
+++ b/drivers/intel/e1000e/e1000e-3.2.7.1-zc/src/netdev.c
@@ -59,7 +59,7 @@ const char e1000e_driver_version[] = DRV_VERSION;
 
 #ifdef HAVE_PF_RING
 //#define ENABLE_RX_ZC
-#include "../../../../../kernel/linux/pf_ring.h"
+#include "pf_ring.h"
 
 static unsigned int enable_debug = 0;
 module_param(enable_debug, uint, 0644);

--- a/drivers/intel/fm10k/fm10k-0.20.1-zc/src/fm10k.h
+++ b/drivers/intel/fm10k/fm10k-0.20.1-zc/src/fm10k.h
@@ -31,7 +31,7 @@
 #include <linux/uio_driver.h>
 
 #ifdef HAVE_PF_RING
-#include "../../../../../kernel/linux/pf_ring.h"
+#include "pf_ring.h"
 #endif
 
 #include "fm10k_pf.h"

--- a/drivers/intel/i40e/i40e-2.3.6-zc/src/i40e/i40e_main.c
+++ b/drivers/intel/i40e/i40e-2.3.6-zc/src/i40e/i40e_main.c
@@ -49,7 +49,7 @@
 #include "i40e_trace.h"
 
 #ifdef HAVE_PF_RING
-#include "../../../../../../kernel/linux/pf_ring.h"
+#include "pf_ring.h"
 
 #define I40E_PCI_DEVICE_CACHE_LINE_SIZE      0x0C
 #define PCI_DEVICE_CACHE_LINE_SIZE_BYTES        8

--- a/drivers/intel/igb/igb-5.3.3.5-zc/src/igb.h
+++ b/drivers/intel/igb/igb-5.3.3.5-zc/src/igb.h
@@ -64,7 +64,7 @@ struct igb_adapter;
 #include "e1000_mbx.h"
 
 #ifdef HAVE_PF_RING
-#include "../../../../../kernel/linux/pf_ring.h"
+#include "pf_ring.h"
 #endif
 
 #define IGB_ERR(args...) pr_err(KERN_ERR "igb: " args)

--- a/drivers/intel/ixgbe/ixgbe-5.0.4-zc/src/ixgbe_82599.c
+++ b/drivers/intel/ixgbe/ixgbe-5.0.4-zc/src/ixgbe_82599.c
@@ -36,7 +36,7 @@
 #define IXGBE_82599_RX_PB_SIZE	  512
 
 #ifdef HAVE_PF_RING
-#include "../../../../../kernel/linux/pf_ring.h"
+#include "pf_ring.h"
 
 static unsigned int allow_tap_1g = 0;
 module_param(allow_tap_1g, uint, 0644);

--- a/drivers/intel/ixgbe/ixgbe-5.0.4-zc/src/ixgbe_ethtool.c
+++ b/drivers/intel/ixgbe/ixgbe-5.0.4-zc/src/ixgbe_ethtool.c
@@ -44,7 +44,7 @@
 #endif
 
 #ifdef HAVE_PF_RING
-#include "../../../../../kernel/linux/pf_ring.h"
+#include "pf_ring.h"
 extern s32 ixgbe_ftqf_add_filter(struct ixgbe_hw *hw, u8 proto, u32 saddr, u16 sport, u32 daddr, u16 dport, u8 rx_queue, u8 filter_id);
 
 #ifdef ETHTOOL_SRXNTUPLE /* was ETHTOOL_RXNTUPLE_ACTION_DROP */

--- a/drivers/intel/ixgbe/ixgbe-5.0.4-zc/src/ixgbe_main.c
+++ b/drivers/intel/ixgbe/ixgbe-5.0.4-zc/src/ixgbe_main.c
@@ -58,7 +58,7 @@
 #endif /* HAVE_VXLAN_RX_OFFLOAD */
 
 #ifdef HAVE_PF_RING
-#include "../../../../../kernel/linux/pf_ring.h"
+#include "pf_ring.h"
 
 #define IXGBE_PCI_DEVICE_CACHE_LINE_SIZE	0x0C
 #define PCI_DEVICE_CACHE_LINE_SIZE_BYTES	8

--- a/userland/Makefile
+++ b/userland/Makefile
@@ -66,6 +66,8 @@ nbpf_clean:
 extcap_clean:
 	cd wireshark/extcap; make clean
 
-install: libpfring pcap
+install: libpfring pcap examples examples_zc
 	cd lib; make install
 	cd libpcap; make install
+	cd examples; make install
+	cd examples_zc; make install

--- a/userland/examples/Makefile.in
+++ b/userland/examples/Makefile.in
@@ -124,7 +124,8 @@ pfsystest: pfsystest.o ${LIBPFRING}
 	${CC} ${CFLAGS} pfsystest.o ${LIBS} -o $@
 
 install: pfcount pfsend
-	cp pfcount pfsend /usr/bin/
+	mkdir -p $(DESTDIR)/usr/bin
+	cp pfcount pfsend $(DESTDIR)/usr/bin/
 
 clean:
 	@rm -f ${TARGETS} *.o *~

--- a/userland/examples/Makefile.in
+++ b/userland/examples/Makefile.in
@@ -123,9 +123,9 @@ pfwrite: pfwrite.o ${LIBPFRING}
 pfsystest: pfsystest.o ${LIBPFRING}
 	${CC} ${CFLAGS} pfsystest.o ${LIBS} -o $@
 
-install: pfcount pfsend
+install:
 	mkdir -p $(DESTDIR)/usr/bin
-	cp pfcount pfsend $(DESTDIR)/usr/bin/
+	cp $(TARGETS) $(DESTDIR)/usr/bin/
 
 clean:
 	@rm -f ${TARGETS} *.o *~

--- a/userland/examples_zc/Makefile.in
+++ b/userland/examples_zc/Makefile.in
@@ -85,5 +85,9 @@ zbalance_DC_ipc: zbalance_DC_ipc.o ${LIBPFRING} Makefile
 zsanitycheck: zsanitycheck.o ${LIBPFRING} Makefile
 	${CC} ${CFLAGS} zsanitycheck.o ${LIBS} -o $@
 
+install:
+	mkdir -p $(DESTDIR)/usr/bin
+	cp $(TARGETS) $(DESTDIR)/usr/bin/
+
 clean:
 	@rm -f ${TARGETS} *.o *~ config.*

--- a/userland/lib/Makefile.in
+++ b/userland/lib/Makefile.in
@@ -159,7 +159,7 @@ install-shared:	${DYNAMICLIB} install-includes
 	cp ${DYNAMICLIB} $(DESTDIR)$(libdir)/
 	cd $(DESTDIR)$(libdir); ln -sf ${DYNAMICLIB} ${DYNAMICLIB}.@VER@
 	cd $(DESTDIR)$(libdir); ln -sf ${DYNAMICLIB} ${DYNAMICLIB}.@MAJOR_VER@
-	@if test "$(USER)" = "root"; then \
+	-@if test "$(USER)" = "root"; then \
 		ldconfig; \
 	fi
 


### PR DESCRIPTION
When building debian packages (and probably other package formats too) we want to be able to run _'make clean'_', _'make'_ and _'make install'_ from the root of the source directory.

This pull request cleans up makefiles to make this possible. It also removes the sed hacks when compiling the drivers in-source. This is done by using C_INCLUDE_PATH to enable both in-source and out-of-source builds without using hard-coded includes.

Hope you'll consider merging this pull request. It makes packaging PF_RING a lot easier :)