### PR TITLE
Fix sw hash filtering comparisons for IPv6 + some debug improvements

### DIFF
--- a/kernel/linux/pf_ring.h
+++ b/kernel/linux/pf_ring.h
@@ -281,8 +281,8 @@ struct pkt_parsing_info {
   u_int16_t vlan_id;          /* VLAN Id or NO_VLAN */
   u_int16_t qinq_vlan_id;     /* VLAN Id or NO_VLAN */
   u_int8_t  ip_version;
-  u_int8_t  l3_proto, ip_tos; /* Layer 4 protocol, TOS */
-  ip_addr   ip_src, ip_dst;   /* IPv4 src/dst IP addresses */
+  u_int8_t  l3_proto, ip_tos; /* Layer 3 protocol, TOS */
+  ip_addr   ip_src, ip_dst;   /* IPv4/6 src/dst IP addresses */
   u_int16_t l4_src_port, l4_dst_port;/* Layer 4 src/dst ports */
   u_int8_t  icmp_type, icmp_code;    /* Variables for ICMP packets */
   struct {
@@ -695,7 +695,7 @@ typedef struct {
   u_int16_t rule_id; /* Future use */
   u_int16_t vlan_id;
   u_int8_t ip_version;
-  u_int8_t proto; /* Layer 4 protocol */
+  u_int8_t proto; /* Layer 3 protocol */
   ip_addr host_peer_a, host_peer_b;
   u_int16_t port_peer_a, port_peer_b;
 


### PR DESCRIPTION
Following my recent IPv6 comparison fix (https://github.com/ntop/PF_RING/pull/316), please consider merging the following fix as well.

Notes about the changes I did:
**(1) The main functions that had to be fixed are hash_bucket_match_rule() and hash_filtering_rule_match().
Both of them don’t support IPv6. Since they both use same comparison, I’ve created a new function
compare_hash_filtering_rules() that both of them use. This new function comparison is inspired by function hash_bucket_match().
Note that in the new function compare_hash_filtering_rules(), in addition to the members that are compared (proto, vlan_id …), I’ve added a comparison of ip_version, since there is no reason to continue the comparison if the ip_version differs.**
(2) Since there are no debug prints for IPv6, I’ve added the function printk_addr() that prints both IPv4 and IPv6 addresses. New debug macros where added (that use it).
(3) Improved error debug messaging when adding duplicate rules. This could have helped me a lot to detect the error that lead me to the suggested fix.
(4) Some printk missing newline fixes
(5) Some comments fixes in pf_ring.h

In addition, here are some suggestions for the future:
1. Make a single addresses match function. I already made the first step by unifying the comparison in hash_bucket_match_rule() and hash_filtering_rule_match(). It’s possible also to do it with hash_bucket_match(), but the problem is that the relevant structs are different (i.e. sw_filtering_hash_bucket and pfring_pkthdr.extended_hdr.parsed_pkt).
This leads to the next suggestion.
2. I think it’s about time to unify the members “protocol, vlan_id, src/dst addresses, src/dst port” in a single new “tuple” struct.
This new "tuple" struct should be a member of other structs like hash_filtering_rule, pkt_parsing_info and many more. This will allow simplifying the code, and to create more generic functions.
