### PR TITLE
New feature to allow flushing ring's queue

### DIFF
--- a/kernel/linux/pf_ring.h
+++ b/kernel/linux/pf_ring.h
@@ -35,6 +35,7 @@
 
 /* Watermark */
 #define DEFAULT_MIN_PKT_QUEUED        128
+#define DEFAULT_POLL_CALLS_TO_FLUSH   0
 
 /* Dirty hack I know, but what else shall I do man? */
 #define pfring_ptr ax25_ptr
@@ -64,6 +65,7 @@
 #define SO_SET_POLL_WATERMARK            117
 #define SO_SET_VIRTUAL_FILTERING_DEVICE  118
 #define SO_REHASH_RSS_PACKET             119
+#define SO_SET_POLL_CALLS_TO_FLUSH       121
 #define SO_SHUTDOWN_RING                 124
 #define SO_PURGE_IDLE_RULES              125 /* inactivity (sec) */
 #define SO_SET_SOCKET_MODE               126
@@ -1144,6 +1146,7 @@ struct pf_ring_socket {
   /* Poll Watermark */
   u_int32_t num_poll_calls;
   u_int16_t poll_num_pkts_watermark;
+  u_int16_t poll_calls_to_flush;
 
   /* Master Ring */
   struct pf_ring_socket *master_ring;

--- a/kernel/pf_ring.c
+++ b/kernel/pf_ring.c
@@ -1555,7 +1555,7 @@ static int ring_proc_get_info(struct seq_file *m, void *data_not_used)
         seq_printf(m, "Hw Filt Rules      : %d\n", pfr->num_hw_filtering_rules);
         seq_printf(m, "Poll Pkt Watermark : %d\n", pfr->poll_num_pkts_watermark);
         seq_printf(m, "Num Poll Calls     : %u\n", pfr->num_poll_calls);
-		seq_printf(m, "Num Poll Calls To Flush Queue   : %u\n", pfr->poll_calls_to_flush);
+	seq_printf(m, "Num Poll Calls To Flush Queue   : %u\n", pfr->poll_calls_to_flush);
       }
 
       if(pfr->zc_device_entry != NULL) {
@@ -6742,14 +6742,14 @@ static int ring_setsockopt(struct socket *sock,
     break;
 
   case SO_SET_POLL_CALLS_TO_FLUSH:
-	  if(optlen != sizeof(u_int16_t))
-		return(-EINVAL);
-	  else {
-		if(copy_from_user(&pfr->poll_calls_to_flush, optval, optlen))
-           return(-EFAULT);
-		debug_printk(2, "--> SO_SET_POLL_CALLS_TO_FLUSH=%u\n", pfr->poll_calls_to_flush);
-	  }
-  	break;
+    if(optlen != sizeof(u_int16_t))
+      return(-EINVAL);
+    else {
+      if(copy_from_user(&pfr->poll_calls_to_flush, optval, optlen))
+        return(-EFAULT);
+      debug_printk(2, "--> SO_SET_POLL_CALLS_TO_FLUSH=%u\n", pfr->poll_calls_to_flush);
+    }
+    break;
 
   case SO_RING_BUCKET_LEN:
     if(optlen != sizeof(u_int32_t))

--- a/userland/lib/pfring.c
+++ b/userland/lib/pfring.c
@@ -618,6 +618,15 @@ int pfring_set_poll_watermark(pfring *ring, u_int16_t watermark) {
 
 /* **************************************************** */
 
+int pfring_set_poll_calls_to_flush(pfring *ring, u_int16_t poll_calls_to_flush) {
+  if(ring && ring->set_poll_calls_to_flush)
+    return ring->set_poll_calls_to_flush(ring, poll_calls_to_flush);
+
+  return(PF_RING_ERROR_NOT_SUPPORTED);
+}
+
+/* **************************************************** */
+
 int pfring_set_poll_duration(pfring *ring, u_int duration) {
   if(ring && ring->set_poll_duration)
     return ring->set_poll_duration(ring, duration);

--- a/userland/lib/pfring.h
+++ b/userland/lib/pfring.h
@@ -244,7 +244,7 @@ struct __pfring {
   int       (*stats)                        (pfring *, pfring_stat *);
   int       (*recv)                         (pfring *, u_char**, u_int, struct pfring_pkthdr *, u_int8_t);
   int       (*set_poll_watermark)           (pfring *, u_int16_t);
-  int       (*set_poll_calls_to_flush)       (pfring *, u_int16_t);
+  int       (*set_poll_calls_to_flush)      (pfring *, u_int16_t);
   int       (*set_poll_duration)            (pfring *, u_int);
   int       (*set_tx_watermark)             (pfring *, u_int16_t);
   int       (*set_channel_id)               (pfring *, u_int32_t);
@@ -521,8 +521,8 @@ int pfring_get_metadata(pfring *ring, u_char **metadata, u_int32_t *metadata_len
 int pfring_set_poll_watermark(pfring *ring, u_int16_t watermark);
 
 /**
- * To avoid situation where packets are waiting in the rings's queue for too long (e.g. low-traffic network), setting this number helps to flush
- * the queue, even if the watermark limit hasn't been reached.
+ * To avoid situation where packets are waiting in the rings's queue too long (e.g. low-traffic network), setting this number helps to flush
+ * the queue, even if the watermark limit hasn't been reached. The higher the given number of poll calls, the slower it will take the queue to be flushed.
  * The default value is 0, which disables flushing the queue in case its not empty.
  * @param ring                The PF_RING handle.
  * @param poll_calls_to_flush The number of poll() calls, till flushing the packets in the queue, if watermark hasn't reached yet.

--- a/userland/lib/pfring.h
+++ b/userland/lib/pfring.h
@@ -244,6 +244,7 @@ struct __pfring {
   int       (*stats)                        (pfring *, pfring_stat *);
   int       (*recv)                         (pfring *, u_char**, u_int, struct pfring_pkthdr *, u_int8_t);
   int       (*set_poll_watermark)           (pfring *, u_int16_t);
+  int       (*set_poll_calls_to_flush)       (pfring *, u_int16_t);
   int       (*set_poll_duration)            (pfring *, u_int);
   int       (*set_tx_watermark)             (pfring *, u_int16_t);
   int       (*set_channel_id)               (pfring *, u_int32_t);
@@ -512,12 +513,22 @@ int pfring_get_metadata(pfring *ring, u_char **metadata, u_int32_t *metadata_len
  * unless at least “watermark” packets have been returned. A low watermark value such as 1, reduces the latency of poll() but likely 
  * increases the number of poll() calls. A high watermark (it cannot exceed 50% of the ring size, otherwise the PF_RING kernel module 
  * will top its value) instead reduces the number of poll() calls but slightly increases the packet latency. 
- * The default value for the watermark (i.e. if user-space applications do not manipulate is value via this call) is 128.
+ * The default value for the watermark (i.e. if user-space applications do not manipulate this value via this call) is 128.
  * @param ring      The PF_RING handle to enable.
  * @param watermark The packet poll watermark.
  * @return 0 on success, a negative value otherwise.
  */
 int pfring_set_poll_watermark(pfring *ring, u_int16_t watermark);
+
+/**
+ * To avoid situation where packets are waiting in the rings's queue for too long (e.g. low-traffic network), setting this number helps to flush
+ * the queue, even if the watermark limit hasn't been reached.
+ * The default value is 0, which disables flushing the queue in case its not empty.
+ * @param ring                The PF_RING handle.
+ * @param poll_calls_to_flush The number of poll() calls, till flushing the packets in the queue, if watermark hasn't reached yet.
+ * @return 0 on success, a negative value otherwise.
+ */
+int pfring_set_poll_calls_to_flush(pfring *ring, u_int16_t poll_calls_to_flush);
 
 /**
  * Set the poll timeout when passive wait is used. 

--- a/userland/lib/pfring_mod.c
+++ b/userland/lib/pfring_mod.c
@@ -195,6 +195,7 @@ int pfring_mod_open(pfring *ring) {
   ring->stats = pfring_mod_stats;
   ring->recv  = pfring_mod_recv;
   ring->set_poll_watermark = pfring_mod_set_poll_watermark;
+  ring->set_poll_calls_to_flush = pfring_mod_set_poll_calls_to_flush; 
   ring->set_poll_duration = pfring_mod_set_poll_duration;
   ring->set_channel_id = pfring_mod_set_channel_id;
   ring->set_channel_mask = pfring_mod_set_channel_mask;
@@ -418,6 +419,12 @@ int  pfring_mod_send(pfring *ring, char *pkt, u_int pkt_len, u_int8_t flush_pack
 
 int pfring_mod_set_poll_watermark(pfring *ring, u_int16_t watermark) {
   return(setsockopt(ring->fd, 0, SO_SET_POLL_WATERMARK, &watermark, sizeof(watermark)));
+}
+
+/* **************************************************** */
+
+int pfring_mod_set_poll_calls_to_flush(pfring *ring, u_int16_t poll_calls_to_flush) {
+  return(setsockopt(ring->fd, 0, SO_SET_POLL_CALLS_TO_FLUSH, &poll_calls_to_flush, sizeof(poll_calls_to_flush)));
 }
 
 /* **************************************************** */

--- a/userland/lib/pfring_mod.h
+++ b/userland/lib/pfring_mod.h
@@ -23,6 +23,7 @@ int pfring_mod_next_pkt_time(pfring *ring, struct timespec *ts);
 int pfring_mod_recv(pfring *ring, u_char** buffer, u_int buffer_len, 
 			  struct pfring_pkthdr *hdr, u_int8_t wait_for_incoming_packet);
 int pfring_mod_set_poll_watermark(pfring *ring, u_int16_t watermark);
+int pfring_mod_set_poll_calls_to_flush(pfring *ring, u_int16_t poll_calls_to_flush);
 int pfring_mod_set_poll_duration(pfring *ring, u_int duration);
 int pfring_mod_add_hw_rule(pfring *ring, hw_filtering_rule *rule);
 int pfring_mod_remove_hw_rule(pfring *ring, u_int16_t rule_id);

--- a/userland/libpcap-1.8.1/pcap-linux.c
+++ b/userland/libpcap-1.8.1/pcap-linux.c
@@ -7256,5 +7256,17 @@ pcap_set_watermark(pcap_t *handle, u_int watermark)
 
 	return ret;
 }
+
+int
+pcap_set_poll_calls_to_flush(pcap_t *handle, u_int16_t poll_calls_to_flush)
+{
+	int ret = -1;
+
+	if (handle->ring) {
+		ret = pfring_set_poll_calls_to_flush(handle->ring, poll_calls_to_flush);
+	}
+
+	return ret;
+}
 #endif
 

--- a/userland/libpcap-1.8.1/pcap/pcap.h
+++ b/userland/libpcap-1.8.1/pcap/pcap.h
@@ -546,6 +546,7 @@ int pcap_set_master_id(pcap_t *handle, u_int32_t master_id);
 int pcap_set_master(pcap_t *handle, pcap_t *master);
 int pcap_set_application_name(pcap_t *handle, char *name);
 int pcap_set_watermark(pcap_t *handle, u_int watermark);
+int pcap_set_poll_calls_to_flush(pcap_t *handle, u_int16_t poll_calls_to_flush);
 #endif
 
 #ifdef HAVE_REMOTE


### PR DESCRIPTION
This feature allows to prevent the situation where packets are waiting too long in the ring's queue, usually on low-traffic networks (e.g. customer's lab environment)

I had the conflict whether to implement it based on time (milliseconds) or counting (polls).
The problem with time-based implementation is that polling (in userspace) can be done not via pf_ring's API, so the library can't know what is the poll() timeout. This could lead to discrepancy between the queue flushing timeout and the poll timeout. Therefore the chosen implementation consists on number of poll() calls, and there is already a counter for that in pf_ring ("num_poll_calls" increased in function ting_poll()).

The main API is pfring_set_poll_calls_to_flush(..), that allows the application to set the number of poll() calls before flushing the queue, even if the queue is not empty (i.e. packets are waiting in the queue, but the watermark hasn't been reached).
The default value is 0, which leaves the current pf_ring kernel module behavior unchanged.
The main logic implementation is in function ring_poll().



