### PR TITLE
Filtering sampling statistics: remove confusing 'miss' and add 'match…

### DIFF
--- a/kernel/linux/pf_ring.h
+++ b/kernel/linux/pf_ring.h
@@ -721,8 +721,8 @@ hash_filtering_rule;
 
 typedef struct {
   u_int64_t match;
-  u_int64_t miss;
   u_int64_t filtered;
+  u_int64_t match_forward;
   u_int32_t inactivity; /* sec */
 } __attribute__((packed))
 hash_filtering_rule_stats;
@@ -731,8 +731,9 @@ hash_filtering_rule_stats;
 
 typedef struct _sw_filtering_hash_bucket {
   hash_filtering_rule           rule;
-  u_int64_t                     match;    /* number of packets matching the rule */
-  u_int64_t                     filtered; /* number of packets filtered by the rule */
+  u_int64_t                     match;         /* number of packets matching the rule */
+  u_int64_t                     filtered;      /* number of packets filtered by the rule */
+  u_int64_t                     match_forward; /* number of packets sampled by the rule (equivalent to match minus filtered) */
   struct _sw_filtering_hash_bucket *next;
 } __attribute__((packed))
 sw_filtering_hash_bucket;

--- a/kernel/pf_ring.c
+++ b/kernel/pf_ring.c
@@ -3601,12 +3601,13 @@ static int add_skb_to_ring(struct sk_buff *skb,
 
     if (hash_found) {
       hash_bucket->rule.internals.jiffies_last_match = jiffies;
-      hash_bucket->match++;		
+      hash_bucket->match++;
       pfr->sw_filtering_hash_match++;
       /* If there is a filter for the session, let 1 packet every first 'filtering_sample_rate' packets, to pass the filter.
        * Note that the above rate keeps the ratio defined by 'FILTERING_SAMPLING_RATIO' */
       if (fwd_pkt == 0 && pfr->filtering_sample_rate && 
           ((hash_bucket->match % (u_int64_t) pfr->filtering_sampling_size) < (u_int64_t)(FILTERING_SAMPLING_RATIO))) {
+          hash_bucket->match_forward++;
           fwd_pkt=1;
       }
 
@@ -7244,7 +7245,7 @@ static int ring_getsockopt(struct socket *sock,
               hash_filtering_rule_stats hfrs;
               hfrs.match = bucket->match;
               hfrs.filtered = bucket->filtered;
-			  hfrs.miss = bucket->match - bucket->filtered;
+              hfrs.match_forward = bucket->match_forward;
               hfrs.inactivity = (u_int32_t) (jiffies_to_msecs(jiffies - bucket->rule.internals.jiffies_last_match) / 1000);
               rc = sizeof(hash_filtering_rule_stats);
               if(copy_to_user(optval, &hfrs, rc)) {

--- a/userland/lib/pfring.h
+++ b/userland/lib/pfring.h
@@ -680,7 +680,7 @@ int pfring_set_sampling_rate(pfring *ring, u_int32_t rate /* 1 = no sampling */)
  * Implement packet sampling during filtering directly into the kernel. Note that this solution is much more efficient than implementing it in user-space. 
  * Sampled packets during filtering are only those that already have been filtered out (if any).
  * @param ring The PF_RING handle on which filtering sampling is applied. 
- * @param rate The filtering sampling rate. Rate of X means 1 packet every X packets is forwarded. A filtering sampling rate of 0 disables sampling.
+ * @param rate The filtering sampling rate. Rate of X means 1 packet every X packets is forwarded. Rate of 0 disables sampling.
  * @return 0 on success, a negative value otherwise.
  */
 int pfring_set_filtering_sampling_rate(pfring *ring, u_int32_t rate /* 0 = no sampling */);


### PR DESCRIPTION
…_forward' for counting filtering sampled packets