### PR TITLE
Fixes to vanilla pf_ring for ARM 32 bit

### DIFF
--- a/kernel/pf_ring.c
+++ b/kernel/pf_ring.c
@@ -1625,8 +1625,7 @@ static void ring_proc_init(pf_ring_net *netns)
   netns->proc_dir = proc_mkdir("pf_ring", netns->net->proc_net);
 
   if (netns->proc_dir == NULL) {
-    printk("[PF_RING] unable to create /proc/net/pf_ring [net=%llu]\n",
-      (long long unsigned) netns->net);
+    printk("[PF_RING] unable to create /proc/net/pf_ring [net=%pK]\n", netns->net);
     return;
   }
 
@@ -1639,13 +1638,11 @@ static void ring_proc_init(pf_ring_net *netns)
 			  &ring_proc_fops /* file operations */);
 
   if (netns->proc == NULL) {
-    printk("[PF_RING] unable to register proc file [net=%llu]\n",
-      (long long unsigned) netns->net);
+    printk("[PF_RING] unable to register proc file [net=%pK]\n", netns->net);
     return;
   }
 
-  debug_printk(1, "registered /proc/net/pf_ring [net=%llu]\n",
-    (long long unsigned) netns->net);
+  debug_printk(1, "registered /proc/net/pf_ring [net=%pK]\n", netns->net);
 }
 
 /* ********************************** */
@@ -1655,8 +1652,7 @@ static void ring_proc_term(pf_ring_net *netns)
   if (netns->proc_dir == NULL) 
     return;
 
-  debug_printk(1, "removing /proc/net/pf_ring [net=%llu]\n", 
-    (long long unsigned) netns->net);
+  debug_printk(1, "removing /proc/net/pf_ring [net=%pK]\n", netns->net);
 
   remove_proc_entry(PROC_INFO,  netns->proc_dir);
   remove_proc_entry(PROC_STATS, netns->proc_dir);
@@ -1664,8 +1660,7 @@ static void ring_proc_term(pf_ring_net *netns)
 
   if (netns->proc != NULL) {
     remove_proc_entry("pf_ring", netns->net->proc_net);
-    debug_printk(1, "deregistered /proc/net/pf_ring [net=%llu]\n",
-      (long long unsigned) netns->net);
+    debug_printk(1, "deregistered /proc/net/pf_ring [net=%pK]\n", netns->net);
   }
 }
 
@@ -7823,10 +7818,8 @@ void remove_device_from_proc(pf_ring_net *netns, pf_ring_device *dev_ptr) {
 #endif
 
   if (dev_ptr->proc_info_entry != NULL) {
-    debug_printk(1, "removing %s/%s from /proc [net=%llu] [entry=%llu]\n", 
-      dev_ptr->device_name, PROC_INFO, 
-      (long long unsigned) netns->net,
-      (long long unsigned) dev_ptr->proc_info_entry);
+    debug_printk(1, "removing %s/%s from /proc [net=%pK] [entry=%pK]\n", 
+      dev_ptr->device_name, PROC_INFO, netns->net, dev_ptr->proc_info_entry);
 
     remove_proc_entry(PROC_INFO, dev_ptr->proc_entry);
 
@@ -7834,10 +7827,8 @@ void remove_device_from_proc(pf_ring_net *netns, pf_ring_device *dev_ptr) {
   }
 
   if (netns->proc_dev_dir != NULL) {
-    debug_printk(1, "removing %s from /proc [net=%llu] [entry=%llu]\n", 
-      dev_ptr->device_name, 
-      (long long unsigned) netns->net,
-      (long long unsigned) dev_ptr->proc_entry);
+    debug_printk(1, "removing %s from /proc [net=%pK] [entry=%pK]\n", 
+      dev_ptr->device_name, netns->net, dev_ptr->proc_entry);
     /* Note: we are not using dev_ptr->dev->name below in case it is changed and has not been updated */
     remove_proc_entry(dev_ptr->device_name, netns->proc_dev_dir);
   }
@@ -7914,15 +7905,13 @@ void add_device_to_proc(pf_ring_net *netns, pf_ring_device *dev_ptr) {
   dev_ptr->proc_entry = proc_mkdir(dev_ptr->device_name, netns->proc_dev_dir);
 
   if (dev_ptr->proc_entry == NULL) {
-    printk("[PF_RING] failure creating %s in /proc [net=%llu]\n", 
-      dev_ptr->device_name, (long long unsigned) netns->net);
+    printk("[PF_RING] failure creating %s in /proc [net=%pK]\n", 
+      dev_ptr->device_name, netns->net);
     return;
   }
 
-  debug_printk(1, "created %s in /proc [net=%llu] [entry=%llu]\n", 
-    dev_ptr->device_name, 
-    (long long unsigned) netns->net,
-    (long long unsigned) dev_ptr->proc_entry);
+  debug_printk(1, "created %s in /proc [net=%pK] [entry=%pK]\n", 
+    dev_ptr->device_name, netns->net, dev_ptr->proc_entry);
 
   dev_ptr->proc_info_entry = proc_create_data(PROC_INFO, 0 /* read-only */,
     dev_ptr->proc_entry,
@@ -7930,15 +7919,13 @@ void add_device_to_proc(pf_ring_net *netns, pf_ring_device *dev_ptr) {
     dev_ptr);
 
   if (dev_ptr->proc_info_entry == NULL) {
-    printk("[PF_RING] failure creating %s/%s in /proc [net=%llu]\n", 
-      dev_ptr->device_name, PROC_INFO, (long long unsigned) netns->net);
+    printk("[PF_RING] failure creating %s/%s in /proc [net=%pK]\n", 
+      dev_ptr->device_name, PROC_INFO, netns->net);
     return;
   }
 
-  debug_printk(1, "created %s/%s in /proc [net=%llu] [entry=%llu]\n", 
-    dev_ptr->device_name, PROC_INFO, 
-    (long long unsigned) netns->net,
-    (long long unsigned) dev_ptr->proc_info_entry);
+  debug_printk(1, "created %s/%s in /proc [net=%pK] [entry=%pK]\n", 
+    dev_ptr->device_name, PROC_INFO, netns->net, dev_ptr->proc_info_entry);
 }
 
 /* ************************************ */
@@ -8298,8 +8285,7 @@ static int __net_init ring_net_init(struct net *net)
 {
   pf_ring_net *netns;
 
-  debug_printk(1, "init network namespace [net=%llu]\n", 
-    (long long unsigned) net);
+  debug_printk(1, "init network namespace [net=%pK]\n", net);
 
   netns = netns_add(net);
 
@@ -8313,8 +8299,7 @@ static int __net_init ring_net_init(struct net *net)
 
 static void __net_exit ring_net_exit(struct net *net)
 {
-  debug_printk(1, "exit network namespace [net=%llu]\n", 
-    (long long unsigned) net);
+  debug_printk(1, "exit network namespace [net=%pK]\n", net);
 
   netns_remove(net);
 }


### PR DESCRIPTION
These two patches fixes the vanilla pf_ring driver for ARM 32 bit platforms. I have tested it on a Zynq board, and also tested on x86_64 for regressions. Please consider merging them.
Thanks,
Daniel Sangorrin