### PR TITLE
pfring_mod.c: fix compilation error

### DIFF
--- a/userland/lib/pfring_mod.c
+++ b/userland/lib/pfring_mod.c
@@ -24,6 +24,7 @@
 #include <ifaddrs.h>
 
 #ifdef ENABLE_BPF
+#include <string.h>
 #include <pcap/pcap.h>
 #include <pcap/bpf.h>
 #include <pcap-int.h>


### PR DESCRIPTION
This commit fixs the error of strlcpy definition.

In file included from ../libpcap/pcap-int.h:388:0,
                 from pfring_mod.c:31:
../libpcap/portability.h:60:11: error: expected declaration specifiers or '...' before '(' token
  (strncpy((x), (y), (z)), \
           ^
../libpcap/portability.h:60:16: error: expected declaration specifiers or '...' before '(' token
  (strncpy((x), (y), (z)), \
                ^
../libpcap/portability.h:60:21: error: expected declaration specifiers or '...' before '(' token
  (strncpy((x), (y), (z)), \
                     ^
../libpcap/portability.h:60:25: error: expected ')' before ',' token
  (strncpy((x), (y), (z)), \
                         ^
Makefile:97: recipe for target 'pfring_mod.o' failed

Signed-off-by: BangLang Huang <banglang.huang@foxmail.com>