### PR TITLE
Add in-tree copy script and configuration diff

### DIFF
--- a/kernel/in-tree/build-config.diff
+++ b/kernel/in-tree/build-config.diff
@@ -1,0 +1,66 @@
+commit fa59986e955b43dcdcc479afe3b122ef0442522b
+Author: RageLtMan <rageltman [at] sempervictus>
+Date:   Sun Jun 24 00:55:33 2018 -0400
+
+    PF_RING: initial commit in-tree of v6.6.0
+    
+    Manually port PF_RING 6.6.0 sources into the kernel tree as DKMS
+    doesnt play well with plugins right now, and installing a test
+    kernel to build the driver and test it with the kernel is tedious
+    and time consuming.
+    
+    Import core drivers and header, adapt old Kconfig and Makefiles
+    from legacy repos such as https://github.com/xrl/pf_ring
+    
+    Option is visible in configuration and built module in initial
+    testing.
+
+diff --git a/net/Kconfig b/net/Kconfig
+index 9dba2715919d..b1f39da0ebba 100644
+--- a/net/Kconfig
++++ b/net/Kconfig
+@@ -453,3 +453,5 @@ config HAVE_CBPF_JIT
+ # Extended BPF JIT (eBPF)
+ config HAVE_EBPF_JIT
+ 	bool
++
++source "net/pf_ring/Kconfig"
+diff --git a/net/Makefile b/net/Makefile
+index 14fede520840..975aee777432 100644
+--- a/net/Makefile
++++ b/net/Makefile
+@@ -86,3 +86,4 @@ obj-y				+= l3mdev/
+ endif
+ obj-$(CONFIG_QRTR)		+= qrtr/
+ obj-$(CONFIG_NET_NCSI)		+= ncsi/
++obj-$(CONFIG_PF_RING)           += pf_ring/
+diff --git a/net/pf_ring/Kconfig b/net/pf_ring/Kconfig
+new file mode 100644
+index 000000000000..0ac61ce02522
+--- /dev/null
++++ b/net/pf_ring/Kconfig
+@@ -0,0 +1,12 @@
++config PF_RING
++	tristate "PF_RING sockets (v6)"
++	---help---
++	  PF_RING socket family, optimized for packet capture.
++          If a PF_RING socket is bound to an adapter (via the bind() system
++          call), such adapter will be used in read-only mode until the socket
++          is destroyed. Whenever an incoming packet is received from the adapter
++          it will not passed to upper layers, but instead it is copied to a ring
++          buffer, which in turn is exported to user space applications via mmap.
++          Please refer to http://luca.ntop.org/Ring.pdf for more.
++
++	  Say N unless you know what you are doing.
+diff --git a/net/pf_ring/Makefile b/net/pf_ring/Makefile
+new file mode 100644
+index 000000000000..23d7bda93a9c
+--- /dev/null
++++ b/net/pf_ring/Makefile
+@@ -0,0 +1,6 @@
++#
++# (C) 2009-18 - ntop.org
++#
++
++obj-$(CONFIG_PF_RING) := pf_ring.o
++

--- a/kernel/in-tree/patch_kernel_tree.sh
+++ b/kernel/in-tree/patch_kernel_tree.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Copy pf_ring source and headers into kernel tree
+# Apply diff to relevant configuration files for in-tree builds
+# Configure KDIR to your source tree and run this script
+
+
+KDIR="/usr/src/linux"
+DIFFDIR="$(cd $( dirname "${BASH_SOURCE[0]}") && pwd )"
+echo "Patching kernel in $KDIR from $DIFFDIR"
+
+if [[ ! -d "$KDIR" ]]; then
+  echo "KDIR improperly set"
+  exit 1
+else
+  if [[ ! -f "$KDIR/Kconfig" ]]; then
+    echo "$KDIR does not appear to be a kernel tree"
+    exit 1
+  fi
+
+  cd "$DIFFDIR"
+  mkdir "$KDIR/net/pf_ring"
+  cp ../pf_ring.c "$KDIR/net/pf_ring"
+  cp ../linux/pf_ring.h "$KDIR/include/linux"
+  
+  cd "$KDIR"
+  if [[  $(patch -p1 -i "$DIFFDIR/build-config.diff") ]]; then
+    echo "Update kernel build configuration to enable PF_RING module"
+    exit 0
+  else
+    echo "Failed to patch kernel tree, review output and PR a fix please"
+    exit 1
+  fi
+fi
+


### PR DESCRIPTION
Script copying the pf_ring.c and .h files into appropriate paths
within the kernel tree, and applying a diff to the makefiles and
kconfigs to enable the relevant configuration options to build
the module together with the kernel.