### PR TITLE
Improve support for cross-compilation

### DIFF
--- a/userland/configure.in
+++ b/userland/configure.in
@@ -5,7 +5,7 @@ AC_CONFIG_FILES(lib/Makefile)
 
 AC_CHECK_HEADERS([linux/net_tstamp.h librdi.h])
 
-MACHINE=`uname -m`
+MACHINE=`$CC -dumpmachine | cut -d '-' -f 1`
 CFLAGS=""
 SYS_LIBS=""
 
@@ -92,7 +92,7 @@ else
 fi
 
 dnl> R/W locks are broken on some BSD releases
-if test "$IS_FREEBSD" != "1"; then
+if test "$IS_FREEBSD" != "1" && test "$cross_compiling" != "yes" ; then
   AC_MSG_CHECKING([if r/w locks are supported])
   AC_TRY_RUN([
   #include <pthread.h>

--- a/userland/lib/Makefile.in
+++ b/userland/lib/Makefile.in
@@ -72,7 +72,7 @@ NPCAP_OBJS  = @NPCAP_OBJS@
 NBPF_HOME = ../nbpf
 NBPF_HDR = ${NBPF_HOME}/nbpf.h
 NBPF_LIB = ${NBPF_HOME}/libnbpf.a
-NBPF_OBJS = `ar t ${NBPF_LIB} | grep -F .o | tr '\n' ' '`
+NBPF_OBJS = `$(AR) t ${NBPF_LIB} | grep -F .o | tr '\n' ' '`
 
 #
 # Object files
@@ -103,13 +103,15 @@ STATICLIB  = libpfring.a
 DYNAMICLIB = libpfring.so
 TARGETS    = ${STATICLIB} ${DYNAMICLIB}
 RING_H     = ../../kernel/linux/pf_ring.h
+AR ?= ar
+RANLIB ?= ranlib
 
 all: ${TARGETS}
 
 ${STATICLIB}: Makefile extract_nbpf @PF_RING_ZC_DEP@ @PF_RING_FT_DEP@ @EXABLAZE_DEP@ @NT_DEP@ @MYRICOM_DEP@ @DAG_DEP@ @FIBERBLAZE_DEP@ @ACCOLADE_DEP@ @NETCOPE_DEP@ @NPCAP_DEP@ ${OBJS} pfring.h ${RING_H}
 	@echo "=*= making library $@ =*="
-	ar rs $@ ${OBJS} ${NBPF_OBJS}
-	ranlib $@
+	$(AR) rs $@ ${OBJS} ${NBPF_OBJS}
+	$(RANLIB) $@
 
 ${DYNAMICLIB}: ${OBJS} extract_nbpf @PF_RING_ZC_DEP@ @PF_RING_FT_DEP@ @EXABLAZE_DEP@ @NT_DEP@ @MYRICOM_DEP@ @DAG_DEP@ @FIBERBLAZE_DEP@ @ACCOLADE_DEP@ @NETCOPE_DEP@ @NPCAP_DEP@ pfring.h ${RING_H} Makefile
 	@echo "=*= making library $@ =*="
@@ -146,7 +148,7 @@ extract_npcap_lib:
 	@AR_X@ @NPCAP_LIB@
 
 extract_nbpf: ${NBPF_LIB}
-	ar x ${NBPF_LIB}
+	$(AR) x ${NBPF_LIB}
 	cp ${NBPF_HDR} .
 
 ${NBPF_LIB}:

--- a/userland/nbpf/Makefile.in
+++ b/userland/nbpf/Makefile.in
@@ -3,6 +3,8 @@ YACC = bison
 INCLUDE = -I../lib -I../../kernel
 LIBS=`../lib/pfring_config --libs` -lpthread #@NDPI_LIB@
 CC=@CC@
+AR ?= ar
+RANLIB ?= ranlib
 CFLAGS=-Wall -fPIC -O2 ${INCLUDE} #@NDPI_INC@ @HAVE_NDPI@
 OBJS=nbpf_mod_rdif.o rules.o tree_match.o parser.o lex.yy.o grammar.tab.o nbpf_mod_fiberblaze.o nbpf_mod_napatech.o
 BPFLIB=libnbpf.a
@@ -10,8 +12,8 @@ BPFLIB=libnbpf.a
 all: nbpftest
 
 $(BPFLIB): $(OBJS)
-	ar rs $@ $(OBJS)
-	ranlib $@
+	$(AR) rs $@ $(OBJS)
+	$(RANLIB) $@
 
 nbpftest: $(BPFLIB) nbpftest.c
 	${CC} $(CFLAGS) -g nbpftest.c -o nbpftest $(BPFLIB) $(LIBS)


### PR DESCRIPTION
"uname -m" fails to detect the target architecture: replace it
with "$(TARGET)gcc -dumpmachine"

Don't invoke directly "ar" / "ranlib" executables: use $(AR) /
$(RANLIB) instead