### PR TITLE
modules: Let LD_LIBRARY_PATH find .so rather than hardcoding absolute paths

### DIFF
--- a/userland/modules/Endace/pfring_mod_dag.c
+++ b/userland/modules/Endace/pfring_mod_dag.c
@@ -92,11 +92,9 @@ static int _pfring_dag_init() {
   if(dag_initialized_ok != 0)
     return(dag_initialized_ok);
 
-  pfring_thirdparty_lib_init("/usr/local/lib/libdag.so", dag_function_ptr); /* src */
-  pfring_thirdparty_lib_init("/usr/lib64/libdag.so", dag_function_ptr); /* rpm */
+  pfring_thirdparty_lib_init("libdag.so", dag_function_ptr);
 
-  pfring_thirdparty_lib_init("/usr/local/lib/libdagconf.so", dag_function_ptr); /* src */
-  pfring_thirdparty_lib_init("/usr/lib64/libdagconf.so", dag_function_ptr); /* rpm */
+  pfring_thirdparty_lib_init("libdagconf.so", dag_function_ptr);
 
   for(i = 0; dag_function_ptr[i].name != NULL; i++) {
     if(dag_function_ptr[i].ptr == NULL) {

--- a/userland/modules/Netcope/pfring_mod_netcope.c
+++ b/userland/modules/Netcope/pfring_mod_netcope.c
@@ -67,7 +67,7 @@ static int __pfring_nsf_init() {
   if (pfring_nsf_initialized_ok != 0)
     return pfring_nsf_initialized_ok;
 
-  pfring_thirdparty_lib_init("/usr/lib64/libnsf.so", pfring_nsf_function_ptr);
+  pfring_thirdparty_lib_init("libnsf.so", pfring_nsf_function_ptr);
 
   for (i = 0; pfring_nsf_function_ptr[i].name != NULL; i++) {
     if (pfring_nsf_function_ptr[i].ptr == NULL) {

--- a/userland/nbpf/nbpf_mod_rdif.c
+++ b/userland/nbpf/nbpf_mod_rdif.c
@@ -897,7 +897,7 @@ nbpf_rdif_handle_t *nbpf_rdif_init(char *ifname) {
   if (rdi_initialized_ok == 0) {
     //Initialize thirdparty libraries
     rdi_initialized_ok = 1;
-    pfring_thirdparty_lib_init("/usr/local/lib/librdif.so", rdi_function_ptr);
+    pfring_thirdparty_lib_init("librdif.so", rdi_function_ptr);
   }
 
   unit = 0; //TODO
@@ -947,7 +947,7 @@ int nbpf_rdif_reset(int unit) {
   if (rdi_initialized_ok == 0) {
     //Initialize thirdparty libraries
     rdi_initialized_ok = 1;
-    pfring_thirdparty_lib_init("/usr/local/lib/librdif.so", rdi_function_ptr);
+    pfring_thirdparty_lib_init("librdif.so", rdi_function_ptr);
   }
   
   /* Set MON2 configuration (value 5). No traffic in egress */


### PR DESCRIPTION
Paths can be different on a variety of distributions, for example Ubuntu packages install libraries to /usr/lib/x86_64-linux-gnu.
In some cases users may need to add /usr/local/lib to ld.so.conf but most modern distributions do this by default.
Fixes #420