### PR TITLE
Fix skb leak in case of looped back broadcast/multicast packet

### DIFF
--- a/kernel/pf_ring.c
+++ b/kernel/pf_ring.c
@@ -4207,8 +4207,10 @@ static int packet_rcv(struct sk_buff *skb, struct net_device *dev,
 {
   int rc;
 
-  if(skb->pkt_type == PACKET_LOOPBACK)
+  if(skb->pkt_type == PACKET_LOOPBACK) {
+    kfree_skb(skb);
     return 0;
+  }
 
   /* avoid loops (e.g. "stack" injected packets captured from kernel) in 1-copy-mode ZC */
   if(skb->pkt_type == PACKET_OUTGOING && active_zc_socket[dev->ifindex] == 2)


### PR DESCRIPTION
It seems that current version has a memory leak with looped back packets. Any looped back broadcast/multicast packet causes the relevant skb to leak. Simple reproducer to exhaust memory resource is to create a veth/dummy device and ping broadcast address or send multicast packets:

```
~ # ip link add dummy-test type dummy
~ # ip addr add 10.20.30.1/24 dev dummy-test
~ # ip link set up dev dummy-test
~ # cat /proc/meminfo | grep SUnreclaim
SUnreclaim:      1560972 kB
~ # ping -b -s60000 -i0.0001 10.20.30.255 -M dont -c10000
WARNING: pinging broadcast address
PING 10.20.30.255 (10.20.30.255) 60000(60028) bytes of data.
^C
--- 10.20.30.255 ping statistics ---
5792 packets transmitted, 0 received, 100% packet loss, time 783ms

~ # cat /proc/meminfo | grep SUnreclaim
SUnreclaim:      2096020 kB
~ #
```