### PR TITLE
Uncommented sed line to fix dkms makefiles for intel drivers

### DIFF
--- a/drivers/intel/Makefile.dkms.e1000e.in
+++ b/drivers/intel/Makefile.dkms.e1000e.in
@@ -5,7 +5,7 @@ add: veryclean
 	mkdir /usr/src/@E1000E@-zc-@E1000E_VERSION@.@REVISION@
 	cd @E1000E@/@E1000E@-@E1000E_VERSION@-zc/src ; make clean; cp -r * /usr/src/@E1000E@-zc-@E1000E_VERSION@.@REVISION@
 	cp ../../kernel/linux/pf_ring.h /usr/src/@E1000E@-zc-@E1000E_VERSION@.@REVISION@
-	#sed -i -e 's|DRIVER_NAME = @E1000E@|DRIVER_NAME = @E1000E@_zc|g' /usr/src/@E1000E@-zc-@E1000E_VERSION@.@REVISION@/Makefile
+	sed -i -e 's|DRIVER_NAME = @E1000E@|DRIVER_NAME = @E1000E@_zc|g' /usr/src/@E1000E@-zc-@E1000E_VERSION@.@REVISION@/Makefile
 	sed -i '/EXTRA_CFLAGS += -DDRIVER_\$$/a DRIVER_NAME=@E1000E@_zc' /usr/src/@E1000E@-zc-@E1000E_VERSION@.@REVISION@/Makefile
 	sed -i 's/..\/..\/..\/..\/..\/kernel/\/usr\/src\/pfring-@PF_RING_VERSION@/g' /usr/src/@E1000E@-zc-@E1000E_VERSION@.@REVISION@/Makefile
 	cp dkms.conf.@E1000E@ /usr/src/@E1000E@-zc-@E1000E_VERSION@.@REVISION@/dkms.conf

--- a/drivers/intel/Makefile.dkms.igb.in
+++ b/drivers/intel/Makefile.dkms.igb.in
@@ -5,7 +5,7 @@ add: remove
 	mkdir /usr/src/@IGB@-zc-@IGB_VERSION@.@REVISION@
 	cd @IGB@/@IGB@-@IGB_VERSION@-zc/src ; make clean; cp -r * /usr/src/@IGB@-zc-@IGB_VERSION@.@REVISION@
 	cp ../../kernel/linux/pf_ring.h /usr/src/@IGB@-zc-@IGB_VERSION@.@REVISION@
-	#sed -i -e 's|DRIVER_NAME=@IGB@|DRIVER_NAME=@IGB@_zc|g' /usr/src/@IGB@-zc-@IGB_VERSION@.@REVISION@/Makefile
+	sed -i -e 's|DRIVER_NAME=@IGB@|DRIVER_NAME=@IGB@_zc|g' /usr/src/@IGB@-zc-@IGB_VERSION@.@REVISION@/Makefile
 	sed -i '/EXTRA_CFLAGS += -DDRIVER_\$$/a DRIVER_NAME=@IGB@_zc' /usr/src/@IGB@-zc-@IGB_VERSION@.@REVISION@/Makefile
 	sed -i 's/..\/..\/..\/..\/..\/kernel/\/usr\/src\/pfring-@PF_RING_VERSION@/g' /usr/src/@IGB@-zc-@IGB_VERSION@.@REVISION@/Makefile
 	cp dkms.conf.@IGB@ /usr/src/@IGB@-zc-@IGB_VERSION@.@REVISION@/dkms.conf

--- a/drivers/intel/Makefile.dkms.ixgbe.in
+++ b/drivers/intel/Makefile.dkms.ixgbe.in
@@ -5,7 +5,7 @@ add: veryclean
 	mkdir /usr/src/@IXGBE@-zc-@IXGBE_VERSION@.@REVISION@
 	cd @IXGBE@/@IXGBE@-@IXGBE_VERSION@-zc/src ; make clean; cp -r * /usr/src/@IXGBE@-zc-@IXGBE_VERSION@.@REVISION@
 	cp ../../kernel/linux/pf_ring.h /usr/src/@IXGBE@-zc-@IXGBE_VERSION@.@REVISION@
-	#sed -i -e 's|DRIVER_NAME=@IXGBE@|DRIVER_NAME=@IXGBE@_zc|g' /usr/src/@IXGBE@-zc-@IXGBE_VERSION@.@REVISION@/Makefile
+	sed -i -e 's|DRIVER_NAME=@IXGBE@|DRIVER_NAME=@IXGBE@_zc|g' /usr/src/@IXGBE@-zc-@IXGBE_VERSION@.@REVISION@/Makefile
 	sed -i '/EXTRA_CFLAGS += -DDRIVER_\$$/a DRIVER_NAME=@IXGBE@_zc' /usr/src/@IXGBE@-zc-@IXGBE_VERSION@.@REVISION@/Makefile
 	sed -i 's/..\/..\/..\/..\/..\/kernel/\/usr\/src\/pfring-@PF_RING_VERSION@/g' /usr/src/@IXGBE@-zc-@IXGBE_VERSION@.@REVISION@/Makefile
 	cp dkms.conf.@IXGBE@ /usr/src/@IXGBE@-zc-@IXGBE_VERSION@.@REVISION@/dkms.conf 

--- a/drivers/intel/Makefile.dkms.ixgbevf.in
+++ b/drivers/intel/Makefile.dkms.ixgbevf.in
@@ -5,7 +5,7 @@ add: veryclean
 	mkdir /usr/src/@IXGBEVF@-zc-@IXGBEVF_VERSION@.@REVISION@
 	cd @IXGBEVF@/@IXGBEVF@-@IXGBEVF_VERSION@-zc/src ; make clean; cp -r * /usr/src/@IXGBEVF@-zc-@IXGBEVF_VERSION@.@REVISION@
 	cp ../../kernel/linux/pf_ring.h /usr/src/@IXGBEVF@-zc-@IXGBEVF_VERSION@.@REVISION@
-	#sed -i -e 's|DRIVER_NAME=@IXGBEVF@|DRIVER_NAME=@IXGBEVF@_zc|g' /usr/src/@IXGBEVF@-zc-@IXGBEVF_VERSION@.@REVISION@/Makefile
+	sed -i -e 's|DRIVER_NAME=@IXGBEVF@|DRIVER_NAME=@IXGBEVF@_zc|g' /usr/src/@IXGBEVF@-zc-@IXGBEVF_VERSION@.@REVISION@/Makefile
 	sed -i '/EXTRA_CFLAGS += -DDRIVER_\$$/a DRIVER_NAME=@IXGBEVF@_zc' /usr/src/@IXGBEVF@-zc-@IXGBEVF_VERSION@.@REVISION@/Makefile
 	sed -i 's/..\/..\/..\/..\/..\/kernel/\/usr\/src\/pfring-@PF_RING_VERSION@/g' /usr/src/@IXGBEVF@-zc-@IXGBEVF_VERSION@.@REVISION@/Makefile
 	cp dkms.conf.@IXGBEVF@ /usr/src/@IXGBEVF@-zc-@IXGBEVF_VERSION@.@REVISION@/dkms.conf 


### PR DESCRIPTION
This fixed errors that occur when using the various Intel device dkms makefiles. I needed this to build the igb driver