### PR TITLE
Only allocate ifindex_map[] slot on device registration

### DIFF
--- a/kernel/pf_ring.c
+++ b/kernel/pf_ring.c
@@ -8404,14 +8404,6 @@ static int ring_notifier(struct notifier_block *this, unsigned long msg, void *d
     return NOTIFY_DONE;
   }
 
-  dev_index = map_ifindex(dev->ifindex);
-
-  if(dev_index < 0) {
-    printk("[PF_RING] %s %s: unable to map interface index %d\n", __FUNCTION__,
-           dev->name, dev->ifindex);
-    return NOTIFY_DONE;
-  }
-
   switch (msg) {
     case NETDEV_POST_INIT:
     case NETDEV_PRE_UP:
@@ -8420,6 +8412,13 @@ static int ring_notifier(struct notifier_block *this, unsigned long msg, void *d
       break;
     case NETDEV_REGISTER:
       debug_printk(2, "%s: [REGISTER][ifindex: %u]\n", dev->name, dev->ifindex);
+
+      dev_index = map_ifindex(dev->ifindex);
+      if(dev_index < 0) {
+        printk("[PF_RING] %s %s: unable to map interface index %d\n", __FUNCTION__,
+          dev->name, dev->ifindex);
+        break;
+      }
 
       /* safety check */
       list_for_each_safe(ptr, tmp_ptr, &ring_aware_device_list) {


### PR DESCRIPTION
If a device doesn't have an entry in `ifindex_map[]`, `pf_ring.c:ring_notifier()` will attempt to allocate one every time it is called. This is true even when the device is being unregistered. When adding and removing a bridge, we will see something like:

```[ 1300.881077] [PF_RING] foo: NETDEV_POST_INIT Type=1 IfIndex=1282 Ptr=d6e86000 Namespace=c0a24a80 Addr=000000000000
[ 1300.893204] [PF_RING] foo: NETDEV_REGISTER Type=1 IfIndex=1282 Ptr=d6e86000 Namespace=c0a24a80 Addr=000000000000
[ 1300.903774] [PF_RING] ring_notifier:8415 indirect mapped ifindex 1282 to 9
[ 1309.851714] [PF_RING] foo: NETDEV_UNREGISTER Type=1 IfIndex=1282 Ptr=d6e86000 Namespace=c0a24a80 Addr=000000000000
[ 1309.862044] [PF_RING] ring_notifier:8449 unmapped ifindex 1282 at 9
[ 1310.040959] [PF_RING] foo: NETDEV_UNREGISTER_FINAL Type=1 IfIndex=1282 Ptr=d6e86000 Namespace=c0a24a80 Addr=000000000000
[ 1310.124388] [PF_RING] ring_notifier:8415 indirect mapped ifindex 1282 to 9
```

Even though the bridge has been deleted, it is consuming a slot incorrectly allocated during `NETDEV_UNREGISTER_FINAL`.