### PR TITLE
add pfring-dkms dependency to pfring-drivers-zc-dkms deb

### DIFF
--- a/drivers/intel/pfring-drivers-zc-dkms/DEBIAN/control
+++ b/drivers/intel/pfring-drivers-zc-dkms/DEBIAN/control
@@ -4,5 +4,5 @@ Maintainer: Luca Deri <deri@ntop.org>
 Version: 1.3
 Package: pfring-drivers-zc-dkms
 Architecture: all
-Depends: e1000e-zc-dkms, igb-zc-dkms, ixgbe-zc-dkms, i40e-zc-dkms, fm10k-zc-dkms
+Depends: pfring-dkms, e1000e-zc-dkms, igb-zc-dkms, ixgbe-zc-dkms, i40e-zc-dkms, fm10k-zc-dkms
 Description: Virtual package for ZC drivers in DKMS format (http://www.ntop.org/pf_ring/).


### PR DESCRIPTION
Installing only pfring-drivers-zc-dkms, dkms fails to compile the modules because pfring source is missing.
