### PR TITLE
Add setting bpf per outzq in zbalance_ipc

### DIFF
--- a/userland/examples_zc/zbalance_ipc.c
+++ b/userland/examples_zc/zbalance_ipc.c
@@ -396,27 +396,27 @@ void sigproc(int sig) {
 
 /* *************************************** */
 
-#define MAX_FILENAME_LEN 256
-#define MAX_CONTENTS_LEN 256
+#define MAX_BPF_FILENAME_LEN 256
+#define MAX_BPF_EXPRESSION_LEN 256
 
-struct file_node {
-  char filename[MAX_FILENAME_LEN];
-  char contents[MAX_CONTENTS_LEN];
-  struct file_node* next;
+struct bpf_file_node {
+  char filename[MAX_BPF_FILENAME_LEN];
+  char expression[MAX_BPF_EXPRESSION_LEN];
+  struct bpf_file_node* next;
 };
 
-struct file_list {
-  struct file_node* head;
+struct bpf_file_list {
+  struct bpf_file_node* head;
   int modified;
 };
 
-static void append_file_list(struct file_list* list, const char* filename) {
-  struct file_node* new_node = (struct file_node*)malloc(sizeof(struct file_node));
+static void append_bpf_file_list(struct bpf_file_list* list, const char* filename) {
+  struct bpf_file_node* new_node = (struct bpf_file_node*)malloc(sizeof(struct bpf_file_node));
   strcpy(new_node->filename, filename);
-  new_node->contents[0] = '\0'; 
+  new_node->expression[0] = '\0'; 
   new_node->next = NULL;
   if (list->head) {
-    struct file_node* node;
+    struct bpf_file_node* node;
     for (node = list->head; node->next; node = node->next);
     node->next = new_node;
   } else
@@ -424,8 +424,8 @@ static void append_file_list(struct file_list* list, const char* filename) {
 }
 
 // signal-safety function
-static char* readline_from_file(const char* filename) {
-  static char buf[MAX_CONTENTS_LEN];
+static char* read_bpf_file(const char* filename) {
+  static char buf[MAX_BPF_EXPRESSION_LEN];
 	int fd;
   if ((fd = open(filename, O_RDONLY)) > 0) {
     int n;
@@ -442,22 +442,22 @@ static char* readline_from_file(const char* filename) {
 }
 
 // signal-safety function
-static void readline_from_file_list(struct file_list* list) {
+static void read_bpf_file_list(struct bpf_file_list* list) {
   list->modified = 0;
-  struct file_node* node;
+  struct bpf_file_node* node;
   for (node = list->head; node; node = node->next) {
-    char* buf = readline_from_file(node->filename);
-    if (buf && strcmp(node->contents, buf)) {
+    char* buf = read_bpf_file(node->filename);
+    if (buf && strcmp(node->expression, buf)) {
       list->modified = 1;
-      strcpy(node->contents, buf);
-      trace(TRACE_NORMAL, "file '%s' loaded : '%s'\n", node->filename, node->contents);
+      strcpy(node->expression, buf);
+      trace(TRACE_NORMAL, "bpf file '%s' : '%s'\n", node->filename, node->expression);
     }
   }
 }
 
-static char** init_inzq_bpf(struct file_list* list, size_t qlen) {
+static char** init_inzq_bpf(struct bpf_file_list* list, size_t qlen) {
   int i;
-  struct file_node* node;
+  struct bpf_file_node* node;
   char** zq_bpf;
   if (!list->head)
     return NULL;
@@ -465,16 +465,16 @@ static char** init_inzq_bpf(struct file_list* list, size_t qlen) {
   // same bpf for all inzq for now
   node = list->head;
   for (i = 0; i < qlen; i++) {
-    zq_bpf[i] = node->contents;
+    zq_bpf[i] = node->expression;
     trace(TRACE_NORMAL, "inqzs[%d] bpf file : %s\n", i, node->filename);
   }
-  readline_from_file_list(list);
+  read_bpf_file_list(list);
   return zq_bpf;
 }
 
-static char** init_outzq_bpf(struct file_list* list, size_t qlen) {
+static char** init_outzq_bpf(struct bpf_file_list* list, size_t qlen) {
   int i;
-  struct file_node* node;
+  struct bpf_file_node* node;
   char** zq_bpf;
   if (!list->head)
     return NULL;
@@ -490,7 +490,7 @@ static char** init_outzq_bpf(struct file_list* list, size_t qlen) {
     while (queue_index) {
       i = atoi(queue_index);
       if (i < qlen) {
-        zq_bpf[i] = node->contents;
+        zq_bpf[i] = node->expression;
         trace(TRACE_NORMAL, "outzqs[%d] bpf file : %s\n", i, node->filename);
       } else {
         trace(TRACE_ERROR, "outzq number(%d) must be less than %d\n", i, num_consumer_queues);
@@ -499,23 +499,23 @@ static char** init_outzq_bpf(struct file_list* list, size_t qlen) {
       queue_index = strtok(NULL, ",");
     }
   }
-  readline_from_file_list(list);
+  read_bpf_file_list(list);
   return zq_bpf;
 }
 
-struct file_list in_bpf_file_list = {NULL, 0};
-struct file_list out_bpf_file_list = {NULL, 0};
+struct bpf_file_list in_bpf_file_list = {NULL, 0};
+struct bpf_file_list out_bpf_file_list = {NULL, 0};
 char** inzq_bpf = NULL;
 char** outzq_bpf = NULL;
 
 void on_bpf_files_modified(int sig) {
-  readline_from_file_list(&in_bpf_file_list);
-  readline_from_file_list(&out_bpf_file_list);
+  read_bpf_file_list(&in_bpf_file_list);
+  read_bpf_file_list(&out_bpf_file_list);
 }
 
 // bpf update should be done in packet_process thread but...
 // - filter_func alone is not enough because if bpf doesn't match at all, it will not be called.
-//   (this is especially for inzq_bpf. if outzq_bpf is evaluated after filter_func.)
+//   (this is especially for inzq_bpf. outzq_bpf is evaluated after filter_func anyway.)
 // - idle_func alone is not enough because if traffic is too busy, it may not be called.
 // that's why we need both filter_func and idle_func, either of them is always called.
 
@@ -622,7 +622,7 @@ void idle_func() {
 
 /* *************************************** */
 
-int64_t filter_func(pfring_zc_pkt_buff *pkt_handle, pfring_zc_queue *in_queue, void *user) {
+int64_t packet_filtering_func(pfring_zc_pkt_buff *pkt_handle, pfring_zc_queue *in_queue, void *user) {
 
   if (inzq_bpf)
     set_inzq_bpf();
@@ -909,7 +909,9 @@ int main(int argc, char* argv[]) {
 #ifdef HAVE_ZMQ
   pthread_t zmq_thread;
 #endif
+  pfring_zc_idle_callback idle_func = NULL;
   pfring_zc_distribution_func distr_func = NULL;
+  pfring_zc_filtering_func filter_func = NULL;
 
   start_time.tv_sec = 0;
 
@@ -947,9 +949,9 @@ int main(int argc, char* argv[]) {
       break;
     case 'f':
       if (strchr(optarg, '@'))
-        append_file_list(&out_bpf_file_list, optarg);
+        append_bpf_file_list(&out_bpf_file_list, optarg);
       else
-        append_file_list(&in_bpf_file_list, optarg);
+        append_bpf_file_list(&in_bpf_file_list, optarg);
       break;
     case 'm':
       hash_mode = atoi(optarg);
@@ -1041,6 +1043,16 @@ int main(int argc, char* argv[]) {
   if (device == NULL) printHelp();
   if (cluster_id < 0) printHelp();
   if (applications == NULL) printHelp();
+
+  if (vlan_filter
+#ifdef HAVE_PF_RING_FT
+      || flow_table
+#endif
+#ifdef HAVE_ZMQ
+      || zmq_server
+#endif
+     )
+    filter_func = packet_filtering_func;
 
   if (vlan_filter != NULL) {
     char *vlan;
@@ -1258,9 +1270,12 @@ int main(int argc, char* argv[]) {
 
   if ((inzq_bpf = init_inzq_bpf(&in_bpf_file_list, num_devices))) {
     set_inzq_bpf();
+    idle_func = set_inzq_bpf;
+    filter_func = packet_filtering_func;
   }
   if ((outzq_bpf = init_outzq_bpf(&out_bpf_file_list, num_consumer_queues))) {
     set_outzq_bpf();
+    filter_func = packet_filtering_func;
   }
 
   wsp = pfring_zc_create_buffer_pool(zc, PREFETCH_BUFFERS);
@@ -1328,7 +1343,8 @@ int main(int argc, char* argv[]) {
 #ifdef HAVE_ZMQ
   signal(SIGHUP, print_filter);
 #endif
-  signal(SIGUSR1, on_bpf_files_modified);
+  if (inzq_bpf || outzq_bpf)
+    signal(SIGUSR1, on_bpf_files_modified);
 
   if (time_pulse) {
     pulse_timestamp_ns = calloc(CACHE_LINE_LEN/sizeof(u_int64_t), sizeof(u_int64_t));


### PR DESCRIPTION
This demonstrates pfring_zc_set_bpf_filter for inzq and outzq.
  -f bpf1 : setting bpf file 'bpf1' for all inzq
  -f bpf1@0,1 -f bpf2@2 : setting bpf file bpf1 for outzq 0,1 and bpf2 for outzq 2(other outzq is not affected)
This uses idle_func and filter_func so I always set idle_func and filter_func for simplicity.

Now zbalance_ipc becomes a software NPB(Network Packet Broker) now.
But remember bpf is expensive. wire-speed is not guaranteed with bpf.