### PR TITLE
Metawatch trailer processing modifications for the userland pf_ring library

### DIFF
--- a/userland/examples/pfcount.c
+++ b/userland/examples/pfcount.c
@@ -727,6 +727,7 @@ void printHelp(void) {
   printf("-K <len>        Print only packets with length > <len> with -v\n");
   printf("-z <mode>       Enabled hw timestamping/stripping. Currently the supported TS mode are:\n"
 	 "                ixia\tTimestamped packets by ixiacom.com hardware devices\n"
+     "                metawatch\tTimestamped packets by Arista 7130 MetaWatch series devices\n"
 	 "                arista\tTimestamped packets by Arista 7150 series devices\n");
   printf("-L              List all interfaces and exit (use -v for more info)\n");
 }
@@ -951,7 +952,7 @@ int main(int argc, char* argv[]) {
   u_char mac_address[6] = { 0 };
   int promisc = 1, snaplen = DEFAULT_SNAPLEN, rc;
   u_int clusterId = 0;
-  u_int8_t enable_ixia_timestamp = 0, enable_arista_timestamp = 0;
+  u_int8_t enable_ixia_timestamp = 0, enable_arista_timestamp = 0, enable_metawatch_timestamp = 0;
   u_int8_t list_interfaces = 0;
   u_int32_t flags = 0;
   int bind_core = -1;
@@ -1103,6 +1104,8 @@ int main(int argc, char* argv[]) {
     case 'z':
       if(strcmp(optarg, "ixia") == 0)
 	enable_ixia_timestamp = 1;
+      else if(strcmp(optarg, "metawatch") == 0)
+    enable_metawatch_timestamp = 1;
       else if(strcmp(optarg, "arista") == 0)
 	enable_arista_timestamp = 1;
       else
@@ -1137,7 +1140,7 @@ int main(int argc, char* argv[]) {
     pfring_config(cpu_percentage);
   }
 
-  if(automa || enable_ixia_timestamp || enable_arista_timestamp) {
+  if(automa || enable_ixia_timestamp || enable_arista_timestamp || enable_metawatch_timestamp) {
     if(snaplen < 1536) {
       snaplen = 1536;
       fprintf(stderr, "WARNING: Snaplen smaller than the MTU. Enlarging it (new snaplen %u)\n", snaplen);
@@ -1166,6 +1169,7 @@ int main(int argc, char* argv[]) {
   if(chunk_mode)              flags |= PF_RING_CHUNK_MODE;
   if(enable_ixia_timestamp)   flags |= PF_RING_IXIA_TIMESTAMP;
   if(enable_arista_timestamp) flags |= PF_RING_ARISTA_TIMESTAMP;
+  if(enable_metawatch_timestamp) flags |= PF_RING_METAWATCH_TIMESTAMP;
   if(asymm_rss)               flags |= PF_RING_ZC_NOT_REPROGRAM_RSS;
   else                        flags |= PF_RING_ZC_SYMMETRIC_RSS;  /* Note that symmetric RSS is ignored by non-ZC drivers */
   /* flags |= PF_RING_FLOW_OFFLOAD | PF_RING_FLOW_OFFLOAD_NOUPDATES;  to receive FlowID on supported adapters*/

--- a/userland/lib/pfring.c
+++ b/userland/lib/pfring.c
@@ -542,14 +542,17 @@ int pfring_loop(pfring *ring, pfringProcesssPacket looper,
         continue; /* rejected */
 #endif
 
-      if (unlikely(ring->flags & (
+      if (likely(ring->flags & (
             PF_RING_IXIA_TIMESTAMP | 
-            PF_RING_VSS_APCON_TIMESTAMP | 
+            PF_RING_VSS_APCON_TIMESTAMP |
+            PF_RING_METAWATCH_TIMESTAMP |
             PF_RING_ARISTA_TIMESTAMP))) {
         if(ring->ixia_timestamp_enabled)
           pfring_handle_ixia_hw_timestamp(buffer, &hdr);
         else if(ring->vss_apcon_timestamp_enabled)
           pfring_handle_vss_apcon_hw_timestamp(buffer, &hdr);
+        else if(ring->flags & PF_RING_METAWATCH_TIMESTAMP)
+            pfring_handle_metawatch_hw_timestamp(buffer, &hdr);
         else if(ring->flags & PF_RING_ARISTA_TIMESTAMP) {
           if (pfring_handle_arista_hw_timestamp(buffer, &hdr) == 1)
             continue; /* skip keyframes */
@@ -623,12 +626,15 @@ recv_next:
 
     if (unlikely(rc > 0 && ring->flags & (
           PF_RING_IXIA_TIMESTAMP | 
-          PF_RING_VSS_APCON_TIMESTAMP | 
+          PF_RING_VSS_APCON_TIMESTAMP |
+          PF_RING_METAWATCH_TIMESTAMP |
           PF_RING_ARISTA_TIMESTAMP))) {
       if(ring->ixia_timestamp_enabled)
         pfring_handle_ixia_hw_timestamp(*buffer, hdr);
       else if(ring->vss_apcon_timestamp_enabled)
         pfring_handle_vss_apcon_hw_timestamp(*buffer, hdr);
+      else if(ring->flags & PF_RING_ARISTA_TIMESTAMP)
+        pfring_handle_metawatch_hw_timestamp(*buffer, hdr);
       else if(ring->flags & PF_RING_ARISTA_TIMESTAMP) {
         if (pfring_handle_arista_hw_timestamp(*buffer, hdr) == 1)
           goto recv_next;

--- a/userland/lib/pfring.h
+++ b/userland/lib/pfring.h
@@ -396,7 +396,8 @@ struct __pfring {
 #define PF_RING_FLOW_OFFLOAD_TUNNEL    (1 << 23) /**< pfring_open() flag: Enable tunnel dissection with flow offload */
 #define PF_RING_DISCARD_INJECTED_PKTS  (1 << 24) /**< pfring_open() flag: Discard packets injected through the stack module (this avoid loops in MITM applications) */
 #define PF_RING_ARISTA_TIMESTAMP       (1 << 25) /**< pfring_open() flag: Enable Arista 7150 hardware timestamp support and stripping */
- 
+#define PF_RING_METAWATCH_TIMESTAMP    (1 << 26) /**< pfring_open() flag: Enable Arista 7150 hardware timestamp support and stripping */
+
 /* ********************************* */
 
 /* backward compatibility */
@@ -1225,6 +1226,23 @@ int pfring_read_ixia_hw_timestamp(u_char *buffer, u_int32_t buffer_len, struct t
  * @return 0 on success, a negative value otherwise.
  */
 int pfring_handle_ixia_hw_timestamp(u_char* buffer, struct pfring_pkthdr *hdr);
+
+/**
+ * Reads a MetaWatch trailer containing, timestamp (ns), device_id, port_id, sub_ns, flags
+ * @param buffer            Incoming packet buffer.
+ * @param ts                If found the hardware timestamp will be placed here
+ * @param hdr               Incoming packet buffer length.
+ * @return The length of the Metwatch timestamp (hence 0 means that the timestamp has not been found).
+ */
+int pfring_read_metawatch_hw_timestamp(u_char *buffer, struct timespec *ts, struct pfring_pkthdr *hdr);
+
+/**
+ * MetaWatch trailer containing, timestamp (ns), device_id, port_id, sub_ns, flags
+ * @param buffer            Incoming packet buffer.
+ * @param hdr               This is an in/out parameter: it is used to read the original packet len, and it is updated (size decreased) if the hw timestamp is found
+ * @return 0 on success, a negative value otherwise.
+ */
+int pfring_handle_metawatch_hw_timestamp(u_char* buffer, struct pfring_pkthdr *hdr);
 
 /**
  * Reads the UTC time and ticks from a ARISTA key frame.

--- a/userland/lib/pfring_hw_timestamp.c
+++ b/userland/lib/pfring_hw_timestamp.c
@@ -29,6 +29,60 @@ void pfring_enable_hw_timestamp_debug() {
 
 /* ********************************* */
 
+int pfring_read_metawatch_hw_timestamp(u_char *buffer, struct timespec *ts, struct pfring_pkthdr *hdr) {
+    u_int32_t buffer_len = hdr->len;
+    double sub_ns = 0.;
+
+    struct metawatch_trailer* trailer = (struct metawatch_trailer *) &buffer[buffer_len - METAWATCH_TRAILER_LEN];
+
+    trailer->ts_sec = ntohl(trailer->ts_sec);
+    trailer->ts_nsec = ntohl(trailer->ts_nsec);
+    trailer->tlv = ntohl(trailer->tlv);
+    trailer->device_id = ntohs(trailer->device_id);
+
+    if ((trailer->flags & METAWATCH_FLAG_TLV_PRESENT) == METAWATCH_FLAG_TLV_PRESENT)
+        sub_ns = (trailer->tlv >> 8) / METAWATCH_SUB_NS_MULTIPLIER;
+
+    if(unlikely(debug_ts))
+        fprintf(stderr, "Flags are %d -> %d.%d(%.9f) - DevID:%d ; PortID:%d\tTLV:%d\n",
+                trailer->flags, trailer->ts_sec, trailer->ts_nsec, sub_ns,
+                trailer->device_id, trailer->port_id, trailer->tlv);
+
+    if(unlikely(thiszone == 0)) thiszone = gmt_to_local(0);
+    ts->tv_sec = trailer->ts_sec - thiszone;
+    ts->tv_nsec = trailer->ts_nsec;
+
+    hdr->extended_hdr.flags = trailer->flags;
+    hdr->extended_hdr.if_index = trailer->port_id;
+    // FIXME: Where should we store the device_id !!!!
+    // hdr->extended_hdr.? = trailer->device_id;
+
+    // TODO: find some sensible check if the decoding was successful
+    return METAWATCH_TRAILER_LEN;
+}
+
+/* ********************************* */
+
+int pfring_handle_metawatch_hw_timestamp(u_char* buffer, struct pfring_pkthdr *hdr) {
+    struct timespec ts;
+    int ts_size;
+
+    if(unlikely(hdr->caplen != hdr->len))
+        return -1; /* full packet only */
+
+    ts_size = pfring_read_metawatch_hw_timestamp(buffer, &ts, hdr);
+
+    if(likely(ts_size > 0)) {
+        hdr->caplen = hdr->len = hdr->len - ts_size;
+        hdr->ts.tv_sec = ts.tv_sec, hdr->ts.tv_usec = ts.tv_nsec/1000;
+        hdr->extended_hdr.timestamp_ns = (((u_int64_t) ts.tv_sec) * 1000000000) + ts.tv_nsec;
+    }
+
+    return 0;
+}
+
+/* ********************************* */
+
 int pfring_read_ixia_hw_timestamp(u_char *buffer, 
 				  u_int32_t buffer_len, struct timespec *ts) {
   struct ixia_hw_ts* ixia;

--- a/userland/lib/pfring_hw_timestamp.h
+++ b/userland/lib/pfring_hw_timestamp.h
@@ -13,6 +13,26 @@
 
 #define IXIA_TS_LEN            19
 
+#define METAWATCH_TRAILER_LEN  16
+#define METAWATCH_FLAG_ORIGINAL_FCS_VALID 0b1
+#define METAWATCH_FLAG_TLV_PRESENT 0b01
+#define METAWATCH_SUB_NS_MULTIPLIER 16777216.  // = 2**24
+#define NS_IN_S 1000000000
+
+// REF: https://stackoverflow.com/questions/18961420/reverse-the-endianness-of-a-c-structure
+#pragma pack(1)
+
+struct metawatch_trailer {
+    u_int32_t tlv;  // if flags[1] is set
+    u_int32_t ts_sec;
+    u_int32_t ts_nsec;
+    u_int8_t flags;
+    u_int16_t device_id;
+    u_int8_t port_id;
+};
+
+/* *********************************************** */
+
 struct ixia_hw_ts {
   u_int8_t type;
   u_int8_t timestamp_len;


### PR DESCRIPTION
Userland PF_RING library and pfcount (test bed app) modifications required to support Arista MetaWatch trailer from 7130 devices.

Related to raise issue #658