### PR TITLE
Fix compiling DKMS ZC drivers against Linux 5.8

### DIFF
--- a/drivers/intel/e1000e/e1000e-3.8.7-zc/src/Kbuild
+++ b/drivers/intel/e1000e/e1000e-3.8.7-zc/src/Kbuild
@@ -20,6 +20,7 @@ e1000e-objs := netdev.o \
 CFLAGS_e1000e_main.o := -I$(src)
 
 EXTRA_CFLAGS += -DHAVE_PF_RING -DIXGBE_NO_HW_RSC -DDISABLE_PACKET_SPLIT
+KBUILD_EXTRA_SYMBOLS=../../../../../kernel/Module.symvers
 
 KVER=$(shell uname -r)
 

--- a/drivers/intel/e1000e/e1000e-3.8.7-zc/src/ethtool.c
+++ b/drivers/intel/e1000e/e1000e-3.8.7-zc/src/ethtool.c
@@ -2844,6 +2844,9 @@ static const struct ethtool_ops e1000_ethtool_ops = {
 #endif
 	.get_coalesce		= e1000_get_coalesce,
 	.set_coalesce		= e1000_set_coalesce,
+#ifdef ETHTOOL_COALESECE_USECS
+	.supported_coalesce_params = ETHTOOL_COALESCE_USECS,
+#endif
 #ifdef ETHTOOL_GRXRINGS
 	.get_rxnfc		= e1000_get_rxnfc,
 #endif

--- a/drivers/intel/e1000e/e1000e-3.8.7-zc/src/ethtool.c
+++ b/drivers/intel/e1000e/e1000e-3.8.7-zc/src/ethtool.c
@@ -2844,7 +2844,7 @@ static const struct ethtool_ops e1000_ethtool_ops = {
 #endif
 	.get_coalesce		= e1000_get_coalesce,
 	.set_coalesce		= e1000_set_coalesce,
-#ifdef ETHTOOL_COALESECE_USECS
+#ifdef ETHTOOL_COALESCE_USECS
 	.supported_coalesce_params = ETHTOOL_COALESCE_USECS,
 #endif
 #ifdef ETHTOOL_GRXRINGS

--- a/drivers/intel/fm10k/fm10k-0.23.5-zc/src/Kbuild
+++ b/drivers/intel/fm10k/fm10k-0.23.5-zc/src/Kbuild
@@ -44,6 +44,7 @@ endif
 fm10k-y += kcompat.o
 
 EXTRA_CFLAGS += -DHAVE_PF_RING
+KBUILD_EXTRA_SYMBOLS=../../../../../kernel/Module.symvers
 
 KVER=$(shell uname -r)
 

--- a/drivers/intel/fm10k/fm10k-0.23.5-zc/src/fm10k_ethtool.c
+++ b/drivers/intel/fm10k/fm10k-0.23.5-zc/src/fm10k_ethtool.c
@@ -30,7 +30,7 @@ struct fm10k_stats {
 
 #define FM10K_NETDEV_STAT(_net_stat) { \
 	.stat_string = #_net_stat, \
-	.sizeof_stat = FIELD_SIZEOF(struct net_device_stats, _net_stat), \
+	.sizeof_stat = sizeof_field(struct net_device_stats, _net_stat), \
 	.stat_offset = offsetof(struct net_device_stats, _net_stat) \
 }
 
@@ -53,7 +53,7 @@ static const struct fm10k_stats fm10k_gstrings_net_stats[] = {
 
 #define FM10K_STAT(_name, _stat) { \
 	.stat_string = _name, \
-	.sizeof_stat = FIELD_SIZEOF(struct fm10k_intfc, _stat), \
+	.sizeof_stat = sizeof_field(struct fm10k_intfc, _stat), \
 	.stat_offset = offsetof(struct fm10k_intfc, _stat) \
 }
 
@@ -94,7 +94,7 @@ static const struct fm10k_stats fm10k_gstrings_pf_stats[] = {
 
 #define FM10K_MBX_STAT(_name, _stat) { \
 	.stat_string = _name, \
-	.sizeof_stat = FIELD_SIZEOF(struct fm10k_mbx_info, _stat), \
+	.sizeof_stat = sizeof_field(struct fm10k_mbx_info, _stat), \
 	.stat_offset = offsetof(struct fm10k_mbx_info, _stat) \
 }
 
@@ -112,7 +112,7 @@ static const struct fm10k_stats fm10k_gstrings_mbx_stats[] = {
 
 #define FM10K_QUEUE_STAT(_name, _stat) { \
 	.stat_string = _name, \
-	.sizeof_stat = FIELD_SIZEOF(struct fm10k_ring, _stat), \
+	.sizeof_stat = sizeof_field(struct fm10k_ring, _stat), \
 	.stat_offset = offsetof(struct fm10k_ring, _stat) \
 }
 
@@ -1311,6 +1311,10 @@ static const struct ethtool_ops fm10k_ethtool_ops = {
 	.set_ringparam		= fm10k_set_ringparam,
 	.get_coalesce		= fm10k_get_coalesce,
 	.set_coalesce		= fm10k_set_coalesce,
+#ifdef ETHTOOL_COALESECE_USECS
+	.supported_coalesce_params = ETHTOOL_COALESCE_USECS |
+	                             ETHTOOL_COALESCE_USE_ADAPTIVE,
+#endif
 	.get_rxnfc		= fm10k_get_rxnfc,
 	.set_rxnfc		= fm10k_set_rxnfc,
 	.get_regs               = fm10k_get_regs,

--- a/drivers/intel/fm10k/fm10k-0.23.5-zc/src/fm10k_ethtool.c
+++ b/drivers/intel/fm10k/fm10k-0.23.5-zc/src/fm10k_ethtool.c
@@ -1311,7 +1311,7 @@ static const struct ethtool_ops fm10k_ethtool_ops = {
 	.set_ringparam		= fm10k_set_ringparam,
 	.get_coalesce		= fm10k_get_coalesce,
 	.set_coalesce		= fm10k_set_coalesce,
-#ifdef ETHTOOL_COALESECE_USECS
+#ifdef ETHTOOL_COALESCE_USECS
 	.supported_coalesce_params = ETHTOOL_COALESCE_USECS |
 	                             ETHTOOL_COALESCE_USE_ADAPTIVE,
 #endif

--- a/drivers/intel/i40e/i40e-2.13.10-zc/src/Kbuild
+++ b/drivers/intel/i40e/i40e-2.13.10-zc/src/Kbuild
@@ -55,6 +55,7 @@ CFLAGS_i40e_main.o := -I$(src)
 #i40e-$(CONFIG_FCOE:m=y) += i40e_fcoe.o
 
 EXTRA_CFLAGS += -DHAVE_PF_RING
+KBUILD_EXTRA_SYMBOLS=../../../../../kernel/Module.symvers
 
 KVER=$(shell uname -r)
 

--- a/drivers/intel/i40e/i40e-2.13.10-zc/src/i40e_ethtool.c
+++ b/drivers/intel/i40e/i40e-2.13.10-zc/src/i40e_ethtool.c
@@ -7031,7 +7031,7 @@ static const struct ethtool_ops i40e_ethtool_ops = {
 #endif
 	.get_coalesce		= i40e_get_coalesce,
 	.set_coalesce		= i40e_set_coalesce,
-#ifdef ETHTOOL_COALESECE_USECS
+#ifdef ETHTOOL_COALESCE_USECS
 	.supported_coalesce_params = ETHTOOL_COALESCE_USECS |
 	                             ETHTOOL_COALESCE_MAX_FRAMES_IRQ |
 	                             ETHTOOL_COALESCE_USE_ADAPTIVE |

--- a/drivers/intel/i40e/i40e-2.13.10-zc/src/i40e_ethtool.c
+++ b/drivers/intel/i40e/i40e-2.13.10-zc/src/i40e_ethtool.c
@@ -7031,6 +7031,13 @@ static const struct ethtool_ops i40e_ethtool_ops = {
 #endif
 	.get_coalesce		= i40e_get_coalesce,
 	.set_coalesce		= i40e_set_coalesce,
+#ifdef ETHTOOL_COALESECE_USECS
+	.supported_coalesce_params = ETHTOOL_COALESCE_USECS |
+	                             ETHTOOL_COALESCE_MAX_FRAMES_IRQ |
+	                             ETHTOOL_COALESCE_USE_ADAPTIVE |
+	                             ETHTOOL_COALESCE_RX_USECS_HIGH |
+	                             ETHTOOL_COALESCE_TX_USECS_HIGH,
+#endif
 #ifndef HAVE_RHEL6_ETHTOOL_OPS_EXT_STRUCT
 #if defined(ETHTOOL_GRSSH) && defined(ETHTOOL_SRSSH)
 	.get_rxfh_key_size	= i40e_get_rxfh_key_size,

--- a/drivers/intel/ice/ice-1.3.2-zc/src/Kbuild
+++ b/drivers/intel/ice/ice-1.3.2-zc/src/Kbuild
@@ -48,6 +48,7 @@ endif
 #ice-$(CONFIG_XDP_SOCKETS) += ice_xsk.o
 
 EXTRA_CFLAGS += -DHAVE_PF_RING
+KBUILD_EXTRA_SYMBOLS=../../../../../kernel/Module.symvers
 
 KVER=$(shell uname -r)
 

--- a/drivers/intel/ice/ice-1.3.2-zc/src/ice_ethtool.c
+++ b/drivers/intel/ice/ice-1.3.2-zc/src/ice_ethtool.c
@@ -5753,7 +5753,7 @@ static const struct ethtool_ops ice_ethtool_ops = {
 	.set_eeprom		= ice_set_eeprom,
 	.get_coalesce		= ice_get_coalesce,
 	.set_coalesce		= ice_set_coalesce,
-#ifdef ETHTOOL_COALESECE_USECS
+#ifdef ETHTOOL_COALESCE_USECS
 	.supported_coalesce_params = ETHTOOL_COALESCE_USECS |
 	                             ETHTOOL_COALESCE_USE_ADAPTIVE |
 	                             ETHTOOL_COALESCE_RX_USECS_HIGH,

--- a/drivers/intel/ice/ice-1.3.2-zc/src/ice_ethtool.c
+++ b/drivers/intel/ice/ice-1.3.2-zc/src/ice_ethtool.c
@@ -5753,6 +5753,11 @@ static const struct ethtool_ops ice_ethtool_ops = {
 	.set_eeprom		= ice_set_eeprom,
 	.get_coalesce		= ice_get_coalesce,
 	.set_coalesce		= ice_set_coalesce,
+#ifdef ETHTOOL_COALESECE_USECS
+	.supported_coalesce_params = ETHTOOL_COALESCE_USECS |
+	                             ETHTOOL_COALESCE_USE_ADAPTIVE |
+	                             ETHTOOL_COALESCE_RX_USECS_HIGH,
+#endif
 	.get_strings		= ice_get_strings,
 	.set_phys_id		= ice_set_phys_id,
 	.get_ethtool_stats      = ice_get_ethtool_stats,

--- a/drivers/intel/igb/igb-5.3.5.18-zc/src/Kbuild
+++ b/drivers/intel/igb/igb-5.3.5.18-zc/src/Kbuild
@@ -25,6 +25,7 @@ igb-objs := igb_main.o \
 CFLAGS_igb_main.o := -I$(src)
 
 EXTRA_CFLAGS += -DHAVE_PF_RING -DIXGBE_NO_HW_RSC -DDISABLE_PACKET_SPLIT
+KBUILD_EXTRA_SYMBOLS=../../../../../kernel/Module.symvers
 
 KVER=$(shell uname -r)
 

--- a/drivers/intel/igb/igb-5.3.5.18-zc/src/igb_ethtool.c
+++ b/drivers/intel/igb/igb-5.3.5.18-zc/src/igb_ethtool.c
@@ -53,7 +53,7 @@ struct igb_stats {
 
 #define IGB_STAT(_name, _stat) { \
 	.stat_string = _name, \
-	.sizeof_stat = FIELD_SIZEOF(struct igb_adapter, _stat), \
+	.sizeof_stat = sizeof_field(struct igb_adapter, _stat), \
 	.stat_offset = offsetof(struct igb_adapter, _stat) \
 }
 
@@ -109,7 +109,7 @@ static const struct igb_stats igb_gstrings_stats[] = {
 
 #define IGB_NETDEV_STAT(_net_stat) { \
 	.stat_string = #_net_stat, \
-	.sizeof_stat = FIELD_SIZEOF(struct net_device_stats, _net_stat), \
+	.sizeof_stat = sizeof_field(struct net_device_stats, _net_stat), \
 	.stat_offset = offsetof(struct net_device_stats, _net_stat) \
 }
 
@@ -3376,6 +3376,9 @@ static const struct ethtool_ops igb_ethtool_ops = {
 #endif
 	.get_coalesce           = igb_get_coalesce,
 	.set_coalesce           = igb_set_coalesce,
+#ifdef ETHTOOL_COALESECE_USECS
+	.supported_coalesce_params = ETHTOOL_COALESCE_USECS,
+#endif
 #ifndef HAVE_RHEL6_ETHTOOL_OPS_EXT_STRUCT
 #ifdef HAVE_ETHTOOL_GET_TS_INFO
 	.get_ts_info            = igb_get_ts_info,

--- a/drivers/intel/igb/igb-5.3.5.18-zc/src/igb_ethtool.c
+++ b/drivers/intel/igb/igb-5.3.5.18-zc/src/igb_ethtool.c
@@ -3376,7 +3376,7 @@ static const struct ethtool_ops igb_ethtool_ops = {
 #endif
 	.get_coalesce           = igb_get_coalesce,
 	.set_coalesce           = igb_set_coalesce,
-#ifdef ETHTOOL_COALESECE_USECS
+#ifdef ETHTOOL_COALESCE_USECS
 	.supported_coalesce_params = ETHTOOL_COALESCE_USECS,
 #endif
 #ifndef HAVE_RHEL6_ETHTOOL_OPS_EXT_STRUCT

--- a/drivers/intel/ixgbe/ixgbe-5.5.3-zc/src/Kbuild
+++ b/drivers/intel/ixgbe/ixgbe-5.5.3-zc/src/Kbuild
@@ -31,6 +31,7 @@ ixgbe-objs := ixgbe_main.o \
 CFLAGS_ixgbe_main.o := -I$(src)
 
 EXTRA_CFLAGS += -DHAVE_PF_RING -DIXGBE_NO_HW_RSC -DDISABLE_PACKET_SPLIT
+KBUILD_EXTRA_SYMBOLS=../../../../../kernel/Module.symvers
 
 KVER=$(shell uname -r)
 

--- a/drivers/intel/ixgbe/ixgbe-5.5.3-zc/src/ixgbe_ethtool.c
+++ b/drivers/intel/ixgbe/ixgbe-5.5.3-zc/src/ixgbe_ethtool.c
@@ -4440,7 +4440,7 @@ static struct ethtool_ops ixgbe_ethtool_ops = {
 #endif
 	.get_coalesce		= ixgbe_get_coalesce,
 	.set_coalesce		= ixgbe_set_coalesce,
-#ifdef ETHTOOL_COALESECE_USECS
+#ifdef ETHTOOL_COALESCE_USECS
 	.supported_coalesce_params = ETHTOOL_COALESCE_USECS,
 #endif
 #ifndef HAVE_NDO_SET_FEATURES

--- a/drivers/intel/ixgbe/ixgbe-5.5.3-zc/src/ixgbe_ethtool.c
+++ b/drivers/intel/ixgbe/ixgbe-5.5.3-zc/src/ixgbe_ethtool.c
@@ -55,7 +55,7 @@ struct ixgbe_stats {
 
 #define IXGBE_NETDEV_STAT(_net_stat) { \
 	.stat_string = #_net_stat, \
-	.sizeof_stat = FIELD_SIZEOF(struct net_device_stats, _net_stat), \
+	.sizeof_stat = sizeof_field(struct net_device_stats, _net_stat), \
 	.stat_offset = offsetof(struct net_device_stats, _net_stat) \
 }
 static const struct ixgbe_stats ixgbe_gstrings_net_stats[] = {
@@ -82,7 +82,7 @@ static const struct ixgbe_stats ixgbe_gstrings_net_stats[] = {
 
 #define IXGBE_STAT(_name, _stat) { \
 	.stat_string = _name, \
-	.sizeof_stat = FIELD_SIZEOF(struct ixgbe_adapter, _stat), \
+	.sizeof_stat = sizeof_field(struct ixgbe_adapter, _stat), \
 	.stat_offset = offsetof(struct ixgbe_adapter, _stat) \
 }
 static struct ixgbe_stats ixgbe_gstrings_stats[] = {
@@ -4440,6 +4440,9 @@ static struct ethtool_ops ixgbe_ethtool_ops = {
 #endif
 	.get_coalesce		= ixgbe_get_coalesce,
 	.set_coalesce		= ixgbe_set_coalesce,
+#ifdef ETHTOOL_COALESECE_USECS
+	.supported_coalesce_params = ETHTOOL_COALESCE_USECS,
+#endif
 #ifndef HAVE_NDO_SET_FEATURES
 	.get_rx_csum		= ixgbe_get_rx_csum,
 	.set_rx_csum		= ixgbe_set_rx_csum,

--- a/drivers/intel/ixgbevf/ixgbevf-4.5.1-zc/src/Kbuild
+++ b/drivers/intel/ixgbevf/ixgbevf-4.5.1-zc/src/Kbuild
@@ -14,6 +14,7 @@ ixgbevf-objs := ixgbevf_main.o \
 CFLAGS_ixgbevf_main.o := -I$(src)
 
 EXTRA_CFLAGS += -DHAVE_PF_RING -DIXGBE_NO_HW_RSC -DDISABLE_PACKET_SPLIT
+KBUILD_EXTRA_SYMBOLS=../../../../../kernel/Module.symvers
 
 KVER=$(shell uname -r)
 

--- a/drivers/intel/ixgbevf/ixgbevf-4.5.1-zc/src/ixgbevf_ethtool.c
+++ b/drivers/intel/ixgbevf/ixgbevf-4.5.1-zc/src/ixgbevf_ethtool.c
@@ -1612,7 +1612,7 @@ static struct ethtool_ops ixgbevf_ethtool_ops = {
 #endif
 	.get_coalesce           = ixgbevf_get_coalesce,
 	.set_coalesce           = ixgbevf_set_coalesce,
-#ifdef ETHTOOL_COALESECE_USECS
+#ifdef ETHTOOL_COALESCE_USECS
 	.supported_coalesce_params = ETHTOOL_COALESCE_USECS,
 #endif
 #ifdef ETHTOOL_GRXRINGS

--- a/drivers/intel/ixgbevf/ixgbevf-4.5.1-zc/src/ixgbevf_ethtool.c
+++ b/drivers/intel/ixgbevf/ixgbevf-4.5.1-zc/src/ixgbevf_ethtool.c
@@ -37,14 +37,14 @@ struct ixgbe_stats {
 #define IXGBEVF_STAT(_name, _stat) { \
 	.stat_string = _name, \
 	.type = IXGBEVF_STATS, \
-	.sizeof_stat = FIELD_SIZEOF(struct ixgbevf_adapter, _stat), \
+	.sizeof_stat = sizeof_field(struct ixgbevf_adapter, _stat), \
 	.stat_offset = offsetof(struct ixgbevf_adapter, _stat) \
 }
 
 #define IXGBEVF_NETDEV_STAT(_net_stat) { \
 	.stat_string = #_net_stat, \
 	.type = NETDEV_STATS, \
-	.sizeof_stat = FIELD_SIZEOF(struct net_device_stats, _net_stat), \
+	.sizeof_stat = sizeof_field(struct net_device_stats, _net_stat), \
 	.stat_offset = offsetof(struct net_device_stats, _net_stat) \
 }
 
@@ -1612,6 +1612,9 @@ static struct ethtool_ops ixgbevf_ethtool_ops = {
 #endif
 	.get_coalesce           = ixgbevf_get_coalesce,
 	.set_coalesce           = ixgbevf_set_coalesce,
+#ifdef ETHTOOL_COALESECE_USECS
+	.supported_coalesce_params = ETHTOOL_COALESCE_USECS,
+#endif
 #ifdef ETHTOOL_GRXRINGS
 	.get_rxnfc		= ixgbevf_get_rxnfc,
 	.set_rxnfc		= ixgbevf_set_rxnfc,


### PR DESCRIPTION
Fixes for compiling ZC drivers against Linux 5.8, as used by the Ubuntu 20.04 HWE kernel.

 * Use the `KBUILD_EXTRA_SYMBOLS` variable to point to the pfring module symbols. Since 5.5 modpost no longer checks `./Module.symvers`
   - See Linux commit [39808e451fdf30d20099a92e5185a0acb028d826](https://github.com/torvalds/linux/commit/39808e451fdf30d20099a92e5185a0acb028d826)
 * Replace `FIELD_SIZEOF` with `sizeof_field`
   -  removed in Linux 5.5; `kcompat.h` already has a define for `sizeof_field`
 * Add ethtool `supported_coalesce_params` parameter based on Linux trunk drivers
   - New as of Linux 5.7