### PR TITLE
pf_ring.c: add missing include file

### DIFF
--- a/kernel/pf_ring.c
+++ b/kernel/pf_ring.c
@@ -96,6 +96,7 @@
 #include <linux/list.h>
 #include <linux/netdevice.h>
 #include <linux/etherdevice.h>
+#include <linux/ethtool.h>
 #include <linux/proc_fs.h>
 #include <linux/if_arp.h>
 #include <linux/if_vlan.h>


### PR DESCRIPTION
https://github.com/ntop/PF_RING/issues/709