### PR TITLE
Proposal: support escape tokens in ifname parts of device name

### DIFF
--- a/userland/lib/Makefile.in
+++ b/userland/lib/Makefile.in
@@ -91,7 +91,7 @@ NBPF_OBJS = `$(AR) t ${NBPF_LIB} | grep -F .o | tr '\n' ' '`
 # Object files
 #
 OBJS_MIN = pfring.o pfring_mod.o pfring_utils.o pfring_mod_stack.o pfring_hw_filtering.o \
-	   pfring_hw_timestamp.o pfring_mod_sysdig.o pfring_mod_pcap.o ${PF_RING_ZC_OBJS} \
+	   pfring_hw_timestamp.o pfring_mod_sysdig.o pfring_mod_pcap.o pfring_device.o ${PF_RING_ZC_OBJS} \
 	   ${AF_XDP_OBJS} ${DAG_OBJS} ${FIBERBLAZE_OBJS} ${NT_OBJS} ${ACCOLADE_OBJS} \
 	   ${MYRICOM_OBJS} ${MLX_OBJS} ${NETCOPE_OBJS} ${EXABLAZE_OBJS} ${NPCAP_OBJS}
 

--- a/userland/lib/pfring_device.c
+++ b/userland/lib/pfring_device.c
@@ -1,0 +1,178 @@
+/*
+ *
+ * (C) 2005-2018 - ntop.org
+ *
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesses General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ *
+ */
+
+#include "pfring_device.h"
+
+void pfring_device_fprint(pfring_device* device, FILE *stream) {
+  uint32_t idx;
+  pfring_device_elem* it;
+
+  if (device->channel_mask == RING_ANY_CHANNEL) {
+    fprintf(stream, "channel: any\n");
+  } else {
+    uint64_t tmp_channel_mask = device->channel_mask;
+    idx = 0;
+    fprintf(stream, "channel:");
+    while (tmp_channel_mask) {
+      if (tmp_channel_mask & 1) {
+        fprintf(stream, " %d", idx);
+      }
+      tmp_channel_mask = tmp_channel_mask >> 1;
+      idx++;
+    }
+    fprintf(stream, "\n");
+  }
+
+  idx = 0;
+  fprintf(stream, "elems:\n");
+  for (it = device->elems; it != NULL; it=it->next) {
+    fprintf(stream, "  elem #%d, ifname: %s, vlan_id: %d\n", idx, it->ifname, it->vlan_id);
+  }
+}
+
+void pfring_device_dump(pfring_device* device) {
+  pfring_device_fprint(device, stdout);
+}
+
+void pfring_device_add_elem(pfring_device* device, char *ifname, u_int16_t vlan_id) {
+  pfring_device_elem *elem = (pfring_device_elem *)malloc(sizeof(pfring_device_elem));
+  elem->ifname = ifname;
+  elem->vlan_id = vlan_id;
+  elem->next = device->elems;
+  device->elems = elem;
+}
+
+u_int64_t pfring_parse_channel_mask_string(char* chmask) {
+  u_int64_t channel_mask = 0;
+  char *tok, *at, *pos;
+
+  /* Syntax
+     ethX@1,5       channel 1 and 5
+     ethX@1-5       channel 1,2...5
+     ethX@1-3,5-7   channel 1,2,3,5,6,7
+     */
+
+  at = strdup(chmask);
+  pos = NULL;
+  tok = strtok_r(at, ",", &pos);
+
+  while(tok != NULL) {
+    char *dash = strchr(tok, '-');
+    int32_t min_val, max_val, i;
+
+    if(dash) {
+      dash[0] = '\0';
+      min_val = atoi(tok);
+      max_val = atoi(&dash[1]);
+
+    } else
+      min_val = max_val = atoi(tok);
+
+    for(i = min_val; i <= max_val; i++)
+      channel_mask |= 1 << i;
+
+    tok = strtok_r(NULL, ",", &pos);
+  }
+  return channel_mask;
+}
+
+pfring_device* pfring_parse_device_name(char* device_name) {
+  pfring_device* dev = (pfring_device *)malloc(sizeof(pfring_device));
+  dev->elems = NULL;
+  dev->channel_mask = RING_ANY_CHANNEL;
+  char *ch;
+
+  u_int8_t is_braced = 0;
+  u_int8_t is_in_vlan = 0;
+  u_int16_t vlan_id = 0;
+  char *curr_ifname = (char *)malloc(IFNAMSIZ);
+  char *curr_ifname_end = curr_ifname;
+  for (ch = device_name; *ch != '\0'; ++ch) {
+    if (is_braced) {
+      if (*ch == ')') {
+        is_braced = 0;
+        continue;
+      } else {
+        goto __raw;
+      }
+    }
+    if (is_in_vlan) {
+      if ((*ch <= '9') && (*ch >= '0')) {
+        vlan_id = vlan_id * 10 + (*ch - '0');
+        continue;
+      } else if ((*ch == ',') || (*ch == '@')) {
+        // down to main routine
+      } else {
+        return NULL;
+      }
+    }
+    switch (*ch) {
+      case '@':
+        goto __channel_mask;
+      case ',':
+        *curr_ifname_end = '\0';
+        pfring_device_add_elem(dev, curr_ifname, vlan_id);
+        curr_ifname = (char *)malloc(IFNAMSIZ);
+        curr_ifname_end = curr_ifname;
+        vlan_id = 0;
+        is_in_vlan = 0;
+        continue;
+      case '(':
+        is_braced = 1;
+        continue;
+      case '.':
+        is_in_vlan = 1;
+        continue;
+      default: break;
+    }
+__raw:
+    *curr_ifname_end = *ch;
+    curr_ifname_end ++;
+    if ((curr_ifname_end - curr_ifname) >= IFNAMSIZ) {
+      return NULL;
+    }
+  }
+
+  if (curr_ifname_end != curr_ifname) {
+    *curr_ifname_end = '\0';
+    pfring_device_add_elem(dev, curr_ifname, vlan_id);
+  }
+
+  return dev;
+
+__channel_mask:
+  if (curr_ifname_end != curr_ifname) {
+    *curr_ifname_end = '\0';
+    pfring_device_add_elem(dev, curr_ifname, vlan_id);
+  }
+
+  char* ch_mask_s = ch + 1;
+  dev->channel_mask = pfring_parse_channel_mask_string(ch_mask_s);
+
+  return dev;
+}
+
+void pfring_device_free(pfring_device* device) {
+  pfring_device_elem *it, *to_free;
+  if (!device) {
+    return;
+  }
+  for (it = device->elems; it != NULL;) {
+    free(it->ifname);
+    to_free = it;
+    it = it->next;
+    free(to_free);
+  }
+  free(device);
+}
+

--- a/userland/lib/pfring_device.h
+++ b/userland/lib/pfring_device.h
@@ -1,0 +1,37 @@
+/*
+ *
+ * (C) 2005-2018 - ntop.org
+ *
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesses General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ *
+ */
+
+#ifndef _PFRING_DEVICE_NAME_H_
+#define _PFRING_DEVICE_NAME_H_
+
+#include "pfring.h"
+#include "pfring_utils.h"
+
+typedef struct pfring_device_elem_s {
+  char *ifname;
+  u_int16_t vlan_id; // 0 for no vlan
+  struct pfring_device_elem_s* next;
+} pfring_device_elem;
+
+typedef struct {
+  u_int64_t channel_mask;
+  pfring_device_elem *elems;
+} pfring_device;
+
+void pfring_device_fprint(pfring_device* device, FILE *stream);
+void pfring_device_dump(pfring_device* device);
+pfring_device* pfring_parse_device_name(char* device_name);
+void pfring_device_free(pfring_device* device);
+
+#endif
+


### PR DESCRIPTION
Currently, PF_RING's pfring_open  supports vlan id after '.' or channel after '@', thus "eth1.2@3-5" will be interpreted as:

* ifname = "eth1"
* vlan id = "2"
* channel = 3, 4, 5

unfortunately, linux ifnames actually support any character other than '\0', and if we name our interface 'eth1.2', we will never be able to open it using current userland lib

This PR refactors the device name parser so that:

* device_name without '(' ')' will be interpreted just as usual, so the ABI compatibility is not broken
* supports escaping tokens within ifnames by adding '(' ')' around them, for example, "(eth1.2)" will cover the above case

there's also pfring_device_dump to show exactly how a device name is parsed for troubleshooting.
