### PR TITLE
use -fPIC on aarch64 to bypass the GOT size limit

### DIFF
--- a/userland/libpcap-1.9.1/aclocal.m4
+++ b/userland/libpcap-1.9.1/aclocal.m4
@@ -498,6 +498,9 @@ AC_DEFUN(AC_LBL_SHLIBS_INIT,
 		    PIC_OPT=-fpic
 		    case "$host_cpu" in
 
+		    aarch64*)
+			PIC_OPT=-fPIC
+			;;
 		    sparc64*)
 			case "$host_os" in
 

--- a/userland/libpcap-1.9.1/configure
+++ b/userland/libpcap-1.9.1/configure
@@ -4038,6 +4038,9 @@ $as_echo "#define const /**/" >>confdefs.h
 		    PIC_OPT=-fpic
 		    case "$host_cpu" in
 
+		    aarch64*)
+			PIC_OPT=-fPIC
+			;;
 		    sparc64*)
 			case "$host_os" in
 


### PR DESCRIPTION
just like on SPARC, gcc -fpic on aarch64 got a GOT size limit of 28k, which is easily exceeded in a slightly larger program, rendering the precompiled libpcap unusable.

This PR fix the issue by using -fPIC instead

quoted from `man gcc`
```
If the GOT size for the linked executable exceeds a machine-specific
maximum size, you get an error message from the linker indicating that
-fpic does not work; in that case, recompile with -fPIC instead.  (These
maximums are 8k on the SPARC, 28k on AArch64 and 32k on the m68k
and RS/6000.  The x86 has no such limit.)
```


