### PR TITLE
libpcap: expose new clustering modes through env vars

### DIFF
--- a/userland/libpcap-1.9.1/pcap-linux.c
+++ b/userland/libpcap-1.9.1/pcap-linux.c
@@ -1674,18 +1674,34 @@ pcap_activate_linux(pcap_t *handle)
 				if (atoi(clusterId) > 0 && atoi(clusterId) < 255) {
 					if (getenv("PCAP_PF_RING_USE_CLUSTER_PER_FLOW"))
 						pfring_set_cluster(handle->ring, atoi(clusterId), cluster_per_flow);
-                			else if (getenv("PCAP_PF_RING_USE_CLUSTER_PER_FLOW_2_TUPLE"))
-                				pfring_set_cluster(handle->ring, atoi(clusterId), cluster_per_flow_2_tuple);
-                			else if (getenv("PCAP_PF_RING_USE_CLUSTER_PER_FLOW_4_TUPLE"))
-                				pfring_set_cluster(handle->ring, atoi(clusterId), cluster_per_flow_4_tuple);
-                			else if (getenv("PCAP_PF_RING_USE_CLUSTER_PER_FLOW_TCP_5_TUPLE"))
-                				pfring_set_cluster(handle->ring, atoi(clusterId), cluster_per_flow_tcp_5_tuple);
+					else if (getenv("PCAP_PF_RING_USE_CLUSTER_PER_FLOW_2_TUPLE"))
+						pfring_set_cluster(handle->ring, atoi(clusterId), cluster_per_flow_2_tuple);
+					else if (getenv("PCAP_PF_RING_USE_CLUSTER_PER_FLOW_4_TUPLE"))
+						pfring_set_cluster(handle->ring, atoi(clusterId), cluster_per_flow_4_tuple);
+					else if (getenv("PCAP_PF_RING_USE_CLUSTER_PER_FLOW_TCP_5_TUPLE"))
+						pfring_set_cluster(handle->ring, atoi(clusterId), cluster_per_flow_tcp_5_tuple);
 					else if (getenv("PCAP_PF_RING_USE_CLUSTER_ROUNDROBIN"))
 						pfring_set_cluster(handle->ring, atoi(clusterId), cluster_round_robin);
-                			else /* Default: if (getenv("PCAP_PF_RING_USE_CLUSTER_PER_FLOW_5_TUPLE")) */
-                				pfring_set_cluster(handle->ring, atoi(clusterId), cluster_per_flow_5_tuple);
-              			}
-	    		}
+					else if (getenv("PCAP_PF_RING_USE_CLUSTER_PER_INNER_FLOW"))
+						pfring_set_cluster(handle->ring, atoi(clusterId), cluster_per_inner_flow);
+					else if (getenv("PCAP_PF_RING_USE_CLUSTER_PER_INNER_FLOW_2_TUPLE"))
+						pfring_set_cluster(handle->ring, atoi(clusterId), cluster_per_inner_flow_2_tuple);
+					else if (getenv("PCAP_PF_RING_USE_CLUSTER_PER_INNER_FLOW_4_TUPLE"))
+						pfring_set_cluster(handle->ring, atoi(clusterId), cluster_per_inner_flow_4_tuple);
+					else if (getenv("PCAP_PF_RING_USE_CLUSTER_PER_INNER_FLOW_5_TUPLE"))
+						pfring_set_cluster(handle->ring, atoi(clusterId), cluster_per_inner_flow_5_tuple);
+					else if (getenv("PCAP_PF_RING_USE_CLUSTER_PER_INNER_FLOW_TCP_5_TUPLE"))
+						pfring_set_cluster(handle->ring, atoi(clusterId), cluster_per_inner_flow_tcp_5_tuple);
+					else if (getenv("PCAP_PF_RING_USE_CLUSTER_PER_FLOW_IP_5_TUPLE"))
+						pfring_set_cluster(handle->ring, atoi(clusterId), cluster_per_flow_ip_5_tuple);
+					else if (getenv("PCAP_PF_RING_USE_CLUSTER_PER_INNER_FLOW_IP_5_TUPLE"))
+						pfring_set_cluster(handle->ring, atoi(clusterId), cluster_per_inner_flow_ip_5_tuple);
+					else if (getenv("PCAP_PF_RING_USE_CLUSTER_PER_FLOW_IP_WITH_DUP_TUPLE"))
+						pfring_set_cluster(handle->ring, atoi(clusterId), cluster_per_flow_ip_with_dup_tuple);
+					else /* Default: if (getenv("PCAP_PF_RING_USE_CLUSTER_PER_FLOW_5_TUPLE")) */
+						pfring_set_cluster(handle->ring, atoi(clusterId), cluster_per_flow_5_tuple);
+				}
+			}
 
 			if (appname = getenv("PCAP_PF_RING_APPNAME"))
 			if (strlen(appname) > 0 && strlen(appname) <= 32)


### PR DESCRIPTION
This fairly straight-forward MR exposes the new inner / tunnel load-balancing hashing schemes through env variables in libpcap. I'm running this (cherry-picked on top of 8.0.0) and it works fine on my sensors with Zeek.