### PR TITLE
userland: remove no more existing libpcap canusb option

### DIFF
--- a/userland/Makefile
+++ b/userland/Makefile
@@ -15,7 +15,7 @@ build_nbpf: config
 	cd nbpf; make
 
 libpcap/Makefile:
-	cd libpcap; ./configure --enable-ipv6 --enable-dbus=no --without-libnl --with-snf=no --disable-bluetooth --disable-canusb --with-dag=no
+	cd libpcap; ./configure --enable-ipv6 --enable-dbus=no --without-libnl --with-snf=no --disable-bluetooth --with-dag=no
 
 pcap: libpfring libpcap/Makefile
 	cd libpcap; make


### PR DESCRIPTION
A warning is trig when building libpcap complaining that
no --disable-canusb doesn't exist.

Since commit [93ca5ff7030aaf1219e1de05ec89a68384bfc50b](https://github.com/the-tcpdump-group/libpcap/commit/93ca5ff7030aaf1219e1de05ec89a68384bfc50b) in libpcap
there is no more configurable canusb option.

Remove this flag

Signed-off-by: Clément Péron <peron.clem@gmail.com>