### PR TITLE
Update pf_ring.c

### DIFF
--- a/kernel/pf_ring.c
+++ b/kernel/pf_ring.c
@@ -8458,7 +8458,9 @@ static struct proto_ops ring_ops = {
   .getname = sock_no_getname,
   .listen = sock_no_listen,
   .shutdown = sock_no_shutdown,
+  #if(LINUX_VERSION_CODE < KERNEL_VERSION(6,5,3))
   .sendpage = sock_no_sendpage,
+  #endif
 
   /* Now the operations that really occur. */
   .release = ring_release,


### PR DESCRIPTION

Please sign (check) the below before submitting the Pull Request:

- [X] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [ ] I have updated the documentation (in doc/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/PF_RING/issues):
No issue - just saw it wasn't compiling again dug about and fixed it.

Describe changes:
Change to remove .sendpage assignment, as that attribute seems to have gone away in 6.5.3 kernel.
Moved it into a kernel version #if.
Obviously, please test - still not a kernel person!