### PR TITLE
Fix `make install` failure using a pristine PF_RING due to missing target deps.

### DIFF
--- a/userland/examples/Makefile.in
+++ b/userland/examples/Makefile.in
@@ -127,7 +127,7 @@ pfsystest: pfsystest.o ${LIBPFRING}
 pftimeline: pftimeline.o ${LIBPFRING}
 	${CC} ${CFLAGS} pftimeline.o ${LIBS} -o $@
 
-install:
+install: $(TARGETS)
 	mkdir -p $(DESTDIR)/usr/bin
 	cp $(TARGETS) $(DESTDIR)/usr/bin/
 

--- a/userland/examples_zc/Makefile.in
+++ b/userland/examples_zc/Makefile.in
@@ -94,7 +94,7 @@ zdelay: zdelay.o ${LIBPFRING} Makefile
 ztime: ztime.o ${LIBPFRING} Makefile
 	${CC} ${CFLAGS} ztime.o ${LIBS} -o $@
 
-install:
+install: $(TARGETS)
 ifneq (@HAVE_PF_RING_ZC@,)
 	mkdir -p $(DESTDIR)/usr/bin
 	cp $(TARGETS) $(DESTDIR)/usr/bin/


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have updated the documentation (in doc/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/PF_RING/issues):


Describe changes:


