### PR TITLE
Make the bpf filter string for `pfring_set_bpf_filter()` unmutable.

### DIFF
--- a/userland/lib/pfring.c
+++ b/userland/lib/pfring.c
@@ -1317,7 +1317,7 @@ int pfring_next_pkt_raw_timestamp(pfring *ring, u_int64_t *ts) {
 
 /* **************************************************** */
 
-int pfring_set_bpf_filter(pfring *ring, char *filter_buffer) {
+int pfring_set_bpf_filter(pfring *ring, const char *filter_buffer) {
   int rc = PF_RING_ERROR_NOT_SUPPORTED;
 
   if (!ring)

--- a/userland/lib/pfring.h
+++ b/userland/lib/pfring.h
@@ -295,7 +295,7 @@ struct __pfring {
   int       (*enable_ring)                  (pfring *);
   int       (*disable_ring)                 (pfring *);
   void      (*shutdown)                     (pfring *);
-  int       (*set_bpf_filter)               (pfring *, char *);
+  int       (*set_bpf_filter)               (pfring *, const char *);
   int       (*remove_bpf_filter)            (pfring *);
   int       (*get_device_clock)             (pfring *, struct timespec *);
   int       (*set_device_clock)             (pfring *, struct timespec *);
@@ -1055,7 +1055,7 @@ int pfring_disable_ring(pfring *ring);
  * @param filter_buffer The filter to set.
  * @return 0 on success, a negative value otherwise.
  */
-int pfring_set_bpf_filter(pfring *ring, char *filter_buffer);
+int pfring_set_bpf_filter(pfring *ring, const char *filter_buffer);
 
 /**
  * Remove the BPF filter. 
@@ -1377,7 +1377,7 @@ void pfring_freealldevs(pfring_if_t *list);
 
 /* ********************************* */
 
-int pfring_parse_bpf_filter(char *filter_buffer, u_int caplen,
+int pfring_parse_bpf_filter(const char *filter_buffer, u_int caplen,
  #ifdef BPF_RELEASE
                             struct bpf_program
 #else

--- a/userland/lib/pfring_mod.c
+++ b/userland/lib/pfring_mod.c
@@ -941,7 +941,7 @@ int __pfring_mod_remove_bpf_filter(pfring *ring) {
 
 /* **************************************************** */
 
-int pfring_mod_set_bpf_filter(pfring *ring, char *filter_buffer) {
+int pfring_mod_set_bpf_filter(pfring *ring, const char *filter_buffer) {
   int rc = -1;
 #ifdef ENABLE_BPF
   pcap_t *p;

--- a/userland/lib/pfring_mod.h
+++ b/userland/lib/pfring_mod.h
@@ -73,7 +73,7 @@ int pfring_mod_set_virtual_device(pfring *ring, virtual_filtering_device_info *i
 int pfring_mod_loopback_test(pfring *ring, char *buffer, u_int buffer_len, u_int test_len);
 int pfring_mod_enable_ring(pfring *ring);
 int pfring_mod_disable_ring(pfring *ring);
-int pfring_mod_set_bpf_filter(pfring *ring, char *filter_buffer);
+int pfring_mod_set_bpf_filter(pfring *ring, const char *filter_buffer);
 int pfring_mod_remove_bpf_filter(pfring *ring);
 int pfring_mod_send_last_rx_packet(pfring *ring, int tx_interface_id);
 void pfring_mod_shutdown(pfring *ring);

--- a/userland/lib/pfring_mod_pcap.c
+++ b/userland/lib/pfring_mod_pcap.c
@@ -231,7 +231,7 @@ int pfring_mod_pcap_stats(pfring *ring, pfring_stat *stats) {
 
 /* **************************************************** */
 
-int pfring_mod_pcap_set_bpf_filter(pfring *ring, char *bpfFilter) {
+int pfring_mod_pcap_set_bpf_filter(pfring *ring, const char *bpfFilter) {
   pfring_pcap *pcap;
   struct bpf_program fcode;
   int rc;

--- a/userland/lib/pfring_mod_pcap.h
+++ b/userland/lib/pfring_mod_pcap.h
@@ -31,6 +31,6 @@ int  pfring_mod_pcap_enable_ring(pfring *ring);
 int  pfring_mod_pcap_stats(pfring *ring, pfring_stat *stats);
 int  pfring_mod_pcap_set_socket_mode(pfring *ring, socket_mode mode);
 int  pfring_mod_pcap_set_poll_watermark(pfring *ring, u_int16_t watermark);
-int  pfring_mod_pcap_set_bpf_filter(pfring *ring, char *filter_buffer);
+int  pfring_mod_pcap_set_bpf_filter(pfring *ring, const char *filter_buffer);
 
 #endif /* _PFRING_MOD_PCAP_H_ */

--- a/userland/lib/pfring_mod_sysdig.c
+++ b/userland/lib/pfring_mod_sysdig.c
@@ -536,7 +536,7 @@ int pfring_mod_sysdig_get_bound_device_ifindex(pfring *ring, int *if_index) {
   The currently accepted syntax is "evt.type=X or evt.type=Y ..." that is a subset
   of the syntax supported by the sysdig command
 */
-int pfring_mod_sysdig_set_bpf_filter(pfring *ring, char *filter_buffer) {
+int pfring_mod_sysdig_set_bpf_filter(pfring *ring, const char *filter_buffer) {
   u_int32_t device_id;
   pfring_sysdig *sysdig;
   char *filter, *item, *where;

--- a/userland/lib/pfring_mod_sysdig.h
+++ b/userland/lib/pfring_mod_sysdig.h
@@ -313,7 +313,7 @@ int  pfring_mod_sysdig_set_socket_mode(pfring *ring, socket_mode mode);
 int  pfring_mod_sysdig_set_poll_watermark(pfring *ring, u_int16_t watermark);
 int  pfring_mod_sysdig_stats(pfring *ring, pfring_stat *stats);
 int  pfring_mod_sysdig_get_bound_device_ifindex(pfring *ring, int *if_index);
-int  pfring_mod_sysdig_set_bpf_filter(pfring *ring, char *filter_buffer);
+int  pfring_mod_sysdig_set_bpf_filter(pfring *ring, const char *filter_buffer);
 int  pfring_mod_sysdig_remove_bpf_filter(pfring *ring);
 
 /* Public functions */

--- a/userland/lib/pfring_utils.c
+++ b/userland/lib/pfring_utils.c
@@ -851,7 +851,7 @@ int pfring_get_mtu_size(pfring* ring) {
 
 /* *************************************** */
 
-int pfring_parse_bpf_filter(char *filter_buffer, u_int caplen,
+int pfring_parse_bpf_filter(const char *filter_buffer, u_int caplen,
 #ifdef BPF_RELEASE
                             struct bpf_program
 #else


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have updated the documentation (in doc/) to reflect the changes made (if applicable)

Describe changes:

It's better to make the BPF string in `pfring_set_bpf_filter()` unmutable. It provides a potential developer an easy hint that it's contents won't change while calling that function.
During my PF_RING journey, I've found similar function's/callback's/typedef's that do not need mutable string's/buffer's.