### PR TITLE
kernel: pf_ring: fix old-style-declaration compilation warning

### DIFF
--- a/kernel/pf_ring.c
+++ b/kernel/pf_ring.c
@@ -277,7 +277,7 @@ static inline void printk_addr(u_int8_t ip_version, ip_addr *addr, u_int16_t por
 
 /* ************************************************* */
 
-const static ip_addr ip_zero = { IN6ADDR_ANY_INIT };
+static const ip_addr ip_zero = { IN6ADDR_ANY_INIT };
 
 static u_int8_t pfring_enabled = 1;
 


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [ ] I have updated the documentation (in doc/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/PF_RING/issues):


Describe changes:

New kernel linux from 6.12 enabled new compilation Warning and this cause errors if -Werror is enabled.

There is currently one line that triggers the following warning:

pf_ring.c:284:1: error: 'static' is not at beginning of declaration [-Werror=old-style-declaration]
  284 | const static ip_addr ip_zero = { IN6ADDR_ANY_INIT };
      | ^~~~~

Implement the trivial fix to mute the warning.
