### PR TITLE
pf_ring: fix virt_to_page() type mismatch

### DIFF
--- a/kernel/pf_ring.c
+++ b/kernel/pf_ring.c
@@ -4925,8 +4925,8 @@ void reserve_memory(unsigned long base, unsigned long mem_len)
 {
   struct page *page, *page_end;
 
-  page_end = virt_to_page(base + mem_len - 1);
-  for(page = virt_to_page(base); page <= page_end; page++)
+  page_end = virt_to_page((void *)(base + mem_len - 1));
+  for(page = virt_to_page((void *)base); page <= page_end; page++)
     SetPageReserved(page);
 }
 
@@ -4934,8 +4934,8 @@ void unreserve_memory(unsigned long base, unsigned long mem_len)
 {
   struct page *page, *page_end;
 
-  page_end = virt_to_page(base + mem_len - 1);
-  for(page = virt_to_page(base); page <= page_end; page++)
+  page_end = virt_to_page((void *)(base + mem_len - 1));
+  for(page = virt_to_page((void *)base); page <= page_end; page++)
     ClearPageReserved(page);
 }
 


### PR DESCRIPTION
Link to the related [issue](https://github.com/ntop/PF_RING/issues): https://github.com/ntop/PF_RING/issues/1011


Describe changes:

Cast base and end addresses to void * before calling virt_to_page(). This avoids integer-to-pointer warnings on newer toolchains and makes the pointer semantics explicit.

This fixes build failures on the following ARM targets on OpenWrt: arm_cortex{9_vfpv3-d16,a15_neon-vfpv4}, powerpc_{464fp,8548}.

Please sign (check) the below before submitting the Pull Request:

- [ ] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [ ] I have updated the documentation (in doc/) to reflect the changes made (if applicable)