### PR TITLE
nbpf: fix parallel make race on bison-generated files

### DIFF
--- a/userland/nbpf/Makefile.in
+++ b/userland/nbpf/Makefile.in
@@ -22,9 +22,10 @@ nbpftest: $(BPFLIB) nbpftest.c
 lex.yy.c: scanner.l grammar.tab.h
 	$(LEX) scanner.l
 
-grammar.tab.h: grammar.tab.c
-
-grammar.tab.c: grammar.y
+# Bison generates grammar.tab.c and grammar.tab.h together in one invocation.
+# Use grouped targets (&:, GNU make >= 4.3) so parallel make waits for both
+# outputs before proceeding, avoiding a race when compiling lex.yy.c.
+grammar.tab.c grammar.tab.h &: grammar.y
 	$(YACC) -d grammar.y
 
 clean:


### PR DESCRIPTION
## Problem

`userland/nbpf/Makefile.in` has a race condition under parallel make (`-jN`, N>1) that causes build failures, particularly with distcc.

bison generates `grammar.tab.c` and `grammar.tab.h` together in a single invocation, but the Makefile modeled them as separate targets:

```makefile
grammar.tab.h: grammar.tab.c   # no recipe — side-effect of bison

grammar.tab.c: grammar.y
	$(YACC) -d grammar.y
```

With parallel make, another job can begin preprocessing `lex.yy.c` (which `#include`s `grammar.tab.h`) before the bison run completes, because make considers the side-effect file available as soon as the recipe *starts* rather than when it *finishes*. distcc amplifies this by running the C preprocessor locally in parallel with other compilation jobs.

Reported in: https://github.com/ntop/PF_RING/issues/1028

## Fix

Use GNU make 4.3 grouped targets (`&:`) to declare that a single bison invocation produces both files:

```makefile
grammar.tab.c grammar.tab.h &: grammar.y
	$(YACC) -d grammar.y
```

This ensures make waits for both outputs before scheduling any dependent jobs.

## Test plan

- [ ] Build with `make -j$(nproc)` succeeds
- [ ] Build with distcc succeeds